### PR TITLE
Fix broken pytests

### DIFF
--- a/playbooks/general/setup_source.yml
+++ b/playbooks/general/setup_source.yml
@@ -18,6 +18,7 @@
   vars:
     orig_src_dir: "{{ trans_sec_source_dir | default('../../..') }}/"
     dest_dir: "{{ trans_sec_dest_dir | default(trans_sec_dir) }}"
+    run_tests: "{{ python_unit_tests | default(false) }}"
 
   tasks:
     - name: install python-pip
@@ -47,3 +48,10 @@
     - name: install {{ dest_dir }} and dependencies into python runtime
       become: yes
       command: "pip install -e {{ dest_dir }}"
+
+    - name: run python unit tests
+      become: yes
+      command: python setup.py test
+      args:
+        chdir: "{{ dest_dir }}"
+      when: run_tests

--- a/playbooks/mininet/setup_host.yml
+++ b/playbooks/mininet/setup_host.yml
@@ -12,4 +12,7 @@
 # limitations under the License.
 ---
 - import_playbook: ../general/setup_source.yml
+  vars:
+    python_unit_tests: true
+
 - import_playbook: generate_inventory.yml

--- a/playbooks/tofino/setup_orchestrator.yml
+++ b/playbooks/tofino/setup_orchestrator.yml
@@ -12,6 +12,8 @@
 # limitations under the License.
 ---
 - import_playbook: ../general/setup_source.yml
+  vars:
+    python_unit_tests: true
 
 - hosts: all
   gather_facts: no

--- a/tests/trans_sec/controller/aggregate_controller_tests.py
+++ b/tests/trans_sec/controller/aggregate_controller_tests.py
@@ -42,5 +42,6 @@ class AggregateControllerTests(unittest.TestCase):
         """
         Tests constructor for class CoreController
         """
-        controller = AggregateController("config_dir", self.topo, '/tmp')
+        controller = AggregateController('bmv2', 'config_dir', self.topo,
+                                         '/tmp')
         self.assertIsNotNone(controller)

--- a/tests/trans_sec/controller/core_controller_tests.py
+++ b/tests/trans_sec/controller/core_controller_tests.py
@@ -42,5 +42,5 @@ class CoreControllerTests(unittest.TestCase):
         """
         Tests constructor for class CoreController
         """
-        controller = CoreController("config_dir", self.topo, '/tmp')
+        controller = CoreController('bmv2', 'config_dir', self.topo, '/tmp')
         self.assertIsNotNone(controller)

--- a/tests/trans_sec/controller/gateway_controller_tests.py
+++ b/tests/trans_sec/controller/gateway_controller_tests.py
@@ -42,5 +42,5 @@ class GatewayControllerTests(unittest.TestCase):
         """
         Tests constructor for class CoreController
         """
-        controller = GatewayController("config_dir", self.topo, '/tmp')
+        controller = GatewayController('bmv2', 'config_dir', self.topo, '/tmp')
         self.assertIsNotNone(controller)


### PR DESCRIPTION
#### What does this PR do?
Fixes all broken (controller) pytests and executes them on the machine running the SDN controller.
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
run mininet and/or tofino P4 automation scripts. On mininet, the pytests should be executed immediately after the source has been installed. On tofino, the pytests should only be executed on the controller host, not on the switches or nodes.
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? Fixes #51
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? yes, the P4 simulators will execute the unit tests each time
