### PR TITLE
Renamed the INT data structure

### DIFF
--- a/p4/aggregate/aggregate.p4
+++ b/p4/aggregate/aggregate.p4
@@ -58,7 +58,7 @@ control TpsAggIngress(inout headers hdr,
     }
 
     action data_inspect_packet(bit<32> device) {
-        hdr.inspection.setValid();
+        hdr.gw_int.setValid();
         forwardedPackets.count(device);
     }
 
@@ -81,7 +81,7 @@ control TpsAggIngress(inout headers hdr,
 
     table data_drop_t {
         key = {
-            hdr.inspection.srcAddr: exact;
+            hdr.gw_int.srcAddr: exact;
             hdr.ipv4.srcAddr: exact;
             hdr.ipv4.dstAddr: exact;
             hdr.udp.dst_port: exact;

--- a/p4/core/core.p4
+++ b/p4/core/core.p4
@@ -40,13 +40,13 @@ control TpsCoreIngress(inout headers hdr,
     counter(MAX_DEVICE_ID, CounterType.packets_and_bytes) droppedPackets;
 
     action data_forward(macAddr_t dstAddr, egressSpec_t port) {
-        hdr.inspection.setInvalid();
+        hdr.gw_int.setInvalid();
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
-        hdr.ipv4.srcAddr = hdr.inspection.deviceAddr;
-        hdr.ipv4.dstAddr = hdr.inspection.dstAddr;
-        hdr.udp.dst_port = hdr.inspection.dstPort;
+        hdr.ipv4.srcAddr = hdr.gw_int.deviceAddr;
+        hdr.ipv4.dstAddr = hdr.gw_int.dstAddr;
+        hdr.udp.dst_port = hdr.gw_int.dstPort;
         hdr.ethernet.etherType = TYPE_IPV4;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
@@ -70,7 +70,7 @@ control TpsCoreIngress(inout headers hdr,
 
     table data_drop_t {
         key = {
-            hdr.inspection.srcAddr: exact;
+            hdr.gw_int.srcAddr: exact;
             hdr.ipv4.srcAddr: exact;
             hdr.ipv4.dstAddr: exact;
             hdr.udp.dst_port: exact;
@@ -128,11 +128,11 @@ control TpsCoreIngress(inout headers hdr,
             standard_metadata.ingress_global_timestamp : exact;
             standard_metadata.mcast_grp : exact;
             standard_metadata.checksum_error : exact;
-            hdr.inspection.srcAddr: exact;
-            hdr.inspection.deviceAddr: exact;
-            hdr.inspection.dstAddr: exact;
-            hdr.inspection.dstPort: exact;
-            hdr.inspection.proto_id: exact;
+            hdr.gw_int.srcAddr: exact;
+            hdr.gw_int.deviceAddr: exact;
+            hdr.gw_int.dstAddr: exact;
+            hdr.gw_int.dstPort: exact;
+            hdr.gw_int.proto_id: exact;
             hdr.ipv4.srcAddr: exact;
             hdr.ipv4.dstAddr: exact;
             hdr.udp.dst_port: exact;

--- a/p4/gateway/gateway.p4
+++ b/p4/gateway/gateway.p4
@@ -58,12 +58,12 @@ control TpsGwIngress(inout headers hdr,
     }
 
     action data_inspect_packet(bit<32> device) {
-        hdr.inspection.setValid();
-        hdr.inspection.srcAddr = hdr.ethernet.srcAddr;
-        hdr.inspection.deviceAddr = hdr.ipv4.srcAddr;
-        hdr.inspection.dstAddr  = hdr.ipv4.dstAddr;
-        hdr.inspection.dstPort = hdr.udp.dst_port;
-        hdr.inspection.proto_id = TYPE_IPV4;
+        hdr.gw_int.setValid();
+        hdr.gw_int.srcAddr = hdr.ethernet.srcAddr;
+        hdr.gw_int.deviceAddr = hdr.ipv4.srcAddr;
+        hdr.gw_int.dstAddr  = hdr.ipv4.dstAddr;
+        hdr.gw_int.dstPort = hdr.udp.dst_port;
+        hdr.gw_int.proto_id = TYPE_IPV4;
         hdr.ethernet.etherType = TYPE_INSPECTION;
         forwardedPackets.count(device);
     }
@@ -87,7 +87,7 @@ control TpsGwIngress(inout headers hdr,
 
     table data_drop_t {
         key = {
-            hdr.inspection.srcAddr: exact;
+            hdr.gw_int.srcAddr: exact;
             hdr.ipv4.srcAddr: exact;
             hdr.ipv4.dstAddr: exact;
             hdr.udp.dst_port: exact;

--- a/p4/include/tps_egress.p4
+++ b/p4/include/tps_egress.p4
@@ -35,7 +35,7 @@ control TpsEgress(inout headers hdr,
 control TpsDeparser(packet_out packet, in headers hdr) {
     apply {
         packet.emit(hdr.ethernet);
-        packet.emit(hdr.inspection);
+        packet.emit(hdr.gw_int);
         packet.emit(hdr.ipv4);
         packet.emit(hdr.udp);
     }

--- a/p4/include/tps_headers.p4
+++ b/p4/include/tps_headers.p4
@@ -59,9 +59,9 @@ header udp_t {
 }
 
 /*************************
-INT Data header definition
+External Gateway INT Data header definition
 **************************/
-header inspection_t {
+header gw_int_t {
     macAddr_t srcAddr;
     ip4Addr_t deviceAddr;
     ip4Addr_t dstAddr;
@@ -80,7 +80,7 @@ struct metadata {
 
 struct headers {
     ethernet_t   ethernet;
-    inspection_t inspection;
+    gw_int_t     gw_int;
     ipv4_t       ipv4;
     udp_t        udp;
 }

--- a/p4/include/tps_ingress.p4
+++ b/p4/include/tps_ingress.p4
@@ -18,11 +18,11 @@ control debug_meta(in metadata meta, in headers hdr)
 {
     table dbg_table {
         key = {
-           hdr.inspection.srcAddr: exact;
-           hdr.inspection.deviceAddr: exact;
-           hdr.inspection.dstAddr: exact;
-           hdr.inspection.dstPort: exact;
-           hdr.inspection.proto_id: exact;
+           hdr.gw_int.srcAddr: exact;
+           hdr.gw_int.deviceAddr: exact;
+           hdr.gw_int.dstAddr: exact;
+           hdr.gw_int.dstPort: exact;
+           hdr.gw_int.proto_id: exact;
            hdr.ipv4.srcAddr: exact;
            hdr.ipv4.dstAddr: exact;
            hdr.udp.dst_port: exact;

--- a/p4/include/tps_parser.p4
+++ b/p4/include/tps_parser.p4
@@ -39,8 +39,8 @@ parser TpsParser(packet_in packet,
     }
 
     state parse_inspection {
-        packet.extract(hdr.inspection);
-        transition select(hdr.inspection.proto_id) {
+        packet.extract(hdr.gw_int);
+        transition select(hdr.gw_int.proto_id) {
             TYPE_IPV4: parse_ipv4;
             default: accept;
         }

--- a/tests/trans_sec/analytics/oinc_tests.py
+++ b/tests/trans_sec/analytics/oinc_tests.py
@@ -13,7 +13,6 @@
 # Unit tests for http_session.py
 import logging
 import sys
-import time
 import unittest
 
 import mock

--- a/tests/trans_sec/analytics/oinc_tests.py
+++ b/tests/trans_sec/analytics/oinc_tests.py
@@ -22,7 +22,7 @@ from scapy.layers.inet import IP, UDP
 from scapy.layers.l2 import Ether
 
 from trans_sec.analytics.oinc import SimpleAE
-from trans_sec.packet.inspect_layer import INSPECT
+from trans_sec.packet.inspect_layer import GatewayINTInspect
 from trans_sec.utils.http_session import HttpSession
 
 # noinspection PyCompatibility
@@ -49,7 +49,7 @@ class SimpleAETests(unittest.TestCase):
         :return:
         """
         pkt = (Ether(src=get_if_hwaddr('lo'), dst='ff:ff:ff:ff:ff:ff') /
-               INSPECT() /
+               GatewayINTInspect() /
                IP(dst='localhost', src='localhost') /
                UDP(dport=1234, sport=1234) /
                'hello')
@@ -62,7 +62,7 @@ class SimpleAETests(unittest.TestCase):
         """
         pkt = Ether(src=get_if_hwaddr('lo'), dst='ff:ff:ff:ff:ff:ff')
         pkt = (pkt /
-               INSPECT() /
+               GatewayINTInspect() /
                IP(dst='localhost', src='localhost') /
                UDP(dport=1234, sport=1234) /
                'hello')
@@ -80,13 +80,13 @@ class SimpleAETests(unittest.TestCase):
         :return:
         """
         pkt1 = (Ether(src=get_if_hwaddr('lo'), dst='ff:ff:ff:ff:ff:ff') /
-                INSPECT(srcAddr='ff:ff:ff:ff:ff:ff') /
+                GatewayINTInspect(srcAddr='ff:ff:ff:ff:ff:ff') /
                 IP(dst='localhost', src='localhost') /
                 UDP(dport=1234, sport=1234) /
                 'hello')
 
         pkt2 = (Ether(src=get_if_hwaddr('lo'), dst='ff:ff:ff:ff:ff:ff') /
-                INSPECT(srcAddr='ff:ff:ff:ff:ff:aa') /
+                GatewayINTInspect(srcAddr='ff:ff:ff:ff:ff:aa') /
                 IP(dst='localhost', src='localhost') /
                 UDP(dport=1234, sport=1234) /
                 'hello')

--- a/trans_sec/analytics/oinc.py
+++ b/trans_sec/analytics/oinc.py
@@ -21,7 +21,7 @@ from scapy.all import sniff
 from scapy.layers.inet import IP
 from scapy.layers.l2 import Ether
 import threading
-from trans_sec.packet.inspect_layer import INSPECT
+from trans_sec.packet.inspect_layer import GatewayINTInspect
 
 logger = logging.getLogger('oinc')
 
@@ -53,8 +53,8 @@ class PacketAnalytics(object):
                            (i.e. 0x1212 for Ethernet)
         """
         logger.info("AE monitoring iface %s", iface)
-        bind_layers(Ether, INSPECT, type=ether_type)
-        bind_layers(INSPECT, IP, proto_id=proto_id)
+        bind_layers(Ether, GatewayINTInspect, type=ether_type)
+        bind_layers(GatewayINTInspect, IP, proto_id=proto_id)
         sniff(iface=iface,
               prn=lambda packet: self.handle_packet(packet, ether_type),
               stop_filter=lambda p: self.sniff_stop.is_set())
@@ -106,11 +106,11 @@ def extract_int_data(packet):
     """
     out = dict(
         srcMac=packet[Ether].src,
-        devMac=packet[INSPECT].srcAddr,
-        devAddr=packet[INSPECT].deviceAddr,
-        dstAddr=packet[INSPECT].dstAddr,
-        dstPort=packet[INSPECT].dstPort,
-        protocol=packet[INSPECT].proto_id,
+        devMac=packet[GatewayINTInspect].srcAddr,
+        devAddr=packet[GatewayINTInspect].deviceAddr,
+        dstAddr=packet[GatewayINTInspect].dstAddr,
+        dstPort=packet[GatewayINTInspect].dstPort,
+        protocol=packet[GatewayINTInspect].proto_id,
         packetLen=len(packet),
     )
     logger.debug('Extracted header data [%s]', out)

--- a/trans_sec/controller/abstract_controller.py
+++ b/trans_sec/controller/abstract_controller.py
@@ -151,7 +151,7 @@ class AbstractController(object):
             table_entry = self.p4info_helper.build_table_entry(
                 table_name='{}.data_drop_t'.format(self.p4_ingress),
                 match_fields={
-                    'hdr.inspection.srcAddr': (attack['src_mac']),
+                    'hdr.gw_int.srcAddr': (attack['src_mac']),
                     'hdr.ipv4.srcAddr': (attack['src_ip']),
                     'hdr.ipv4.dstAddr': (attack['dst_ip']),
                     'hdr.udp.dst_port': (int(attack['dst_port']))

--- a/trans_sec/packet/inspect_layer.py
+++ b/trans_sec/packet/inspect_layer.py
@@ -14,7 +14,7 @@ from scapy.all import Packet
 from scapy import fields
 
 
-class INSPECT(Packet):
+class GatewayINTInspect(Packet):
     """
     This class represents the INT data being placed onto the packets to help
     generating and parsing


### PR DESCRIPTION
#### What does this PR do?
Fixes #61 
Renames the INT data structure in P4 from 'inspection' to 'gw_int' as we will be creating 2 different headers, one to be populated by the customer gateway and another to be used only within the provider's core network
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
run automation for mininet
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
