### PR TITLE
Update to use current header as a foundation

### DIFF
--- a/docs/int_header/INT_header.md
+++ b/docs/int_header/INT_header.md
@@ -67,11 +67,11 @@ The hop-by-hop INT header will follow the header as described in section 4.7. IN
 the MAC address of the origionating device:
 
   * Transparent Secuirty the following bits:
-  * bit0: 
+  * bit0: 4 octect Switch ID which is unique accross the network
   * bit8: Originating Device MAC (Most signifigant 4 octets)
   * bit9: Originating Device MAC (Least signifigant 2 octets + 2 octets of 0 padding)
 
-### INT Metadata record (12 bytes)
+### Per Hop INT Metadata record (12 bytes)
 
 This metadata will only contain one record and will not be updated on subsequent hops.
 
@@ -84,6 +84,8 @@ Each metadata record corresponds to a bit filed in the instruction set and is 4 
 On the customer's gateway, the gateway enters it's ID as the switch ID and it inserts the originating devices MAC address.
 
 If the INT header is created on a swtich inside the head end.  This occurs when a header is not adding on the customer premises.  Two entries are added, one for the gateway device.  In a DOCSIS network this is the cable modem.
+
+On subsequent hops where it isn't connected to the originating device or the originating device is not know, 0xFFFFFFFF be  will inserted in the two "Originating Device MAC" records.
 
 ## Examples
 

--- a/docs/int_header/INT_header.md
+++ b/docs/int_header/INT_header.md
@@ -17,6 +17,10 @@ The INT IP shim header and the INT header(s) will be inserted after the IP heade
 
 The INT header is defined in two portions.  One is the Header for the INT metadata and the second is the actual metadata.  For both of these, we follow the INT specification with the addition of two bitmasks.  This additional value, an 8 octctet value for the originating device ID will be proposed to be added to the INT specification.
 
+Please reffer to the 2.0 draft or release version of the P4 Application for the metadata header format.  This document includes the definition of the additional metadata types for the origionating device and a proposed IP shim.
+
+The other shim types, including UDP/TCP can also be used with the probe marker and not the differentiated service bit (DSCP), but those do not cover the range of IP traffic that is used in DDoS attacks.
+
 ## IP Header update
 
 ### Encapsulation
@@ -37,9 +41,9 @@ IPv6:
 * The INT header next header field will be the existing IPv6 next header value.
 * The Hdr Ext Len will be updated appropriately
 
-### IP header shim
+### IP header shim (4 bytes)
 
-Need to develop and IP shim.  This shim shall be 4 bytes and include the origional protocl (IPv4) or next protol (IPv6) and the lenght of the INT meta data.
+This shim shall be 4 bytes and include the origional protocl (IPv4) or next protol (IPv6) and the lenght of the INT meta data.
 
 Type: (1 octect) This field indicates the type of INT Header following the shim header. Two Type values are used: one for the hop-by-hop header type and the other for the destination header type.
 
@@ -55,7 +59,7 @@ The original protocol / next header will be restored and the size and checksum w
 
 ## INT Header
 
-### INT metadata header (64 bits)
+### INT metadata header (12 bytes)
 
 The hop-by-hop INT header will follow the header as described in section 4.7. INT Hop-by-Hop Metadata Header Format in the current INT specification.
 
@@ -65,7 +69,7 @@ the MAC address of the origionating device.
   * bit8: Originating Device MAC (Most signifigant 4 octets)
   * bit9: Originating Device MAC (Least signifigant 2 octets + 2 octets of 0 padding)
 
-### INT Metadata record (96 bits)
+### INT Metadata record (12 bytes)
 
 This metadata will only contain one record and will not be updated on subsequent hops.
 
@@ -73,7 +77,7 @@ Each metadata record corresponds to a bit filed in the instruction set and is 4 
 
 * Switch ID: Unique identifier for the swtich (4 octets)
 * Originating Device MAC Most signifigant 4 octets (4 octets)
-* Originating Device MAC least signifigant 2 octets + 2 octets of padding (4 octets)
+* Originating Device MAC least signifigant 2 octets + 2 octets of reserved padding (4 octets)
 
 On the customer's gateway, the gateway enters it's ID as the switch ID and it inserts the originating devices MAC address.
 
@@ -170,24 +174,24 @@ If the INT header is created on a swtich inside the head end.  This occurs when 
  </tr>
  <tr height=21 style='height:16.0pt'>
   <td height=42 class=xl65 style='height:32.0pt'>IP Shim</td>
-  <td colspan=8 class=xl63>Type</td>
+  <td colspan=8 class=xl63>Type = <font color="red">1</font></td>
   <td colspan=8 class=xl63>Reserved</td>
+  <td colspan=8 class=xl63>Length = <font color="red">6</font></td>
   <td colspan=8 class=xl63>Next Protocol</td>
-  <td colspan=8 class=xl63>Length</td>
  </tr>
  <tr height=21 style='height:16.0pt'>
   <td rowspan=2 height=42 class=xl65 style='height:32.0pt'>Header</td>
-  <td colspan=4 class=xl63>Ver</td>
-  <td colspan=2 class=xl63>Rep</td>
-  <td>C</td>
-  <td>E</td>
-  <td>M</td>
+  <td colspan=4 class=xl63>Verstion = <font color="red">2</font></td>
+  <td colspan=2 class=xl63>Rep = <font color="red">0</font></td>
+  <td>C = <font color="red">0</font></td>
+  <td>E = <font color="red">0</font></td>
+  <td>M = <font color="red">0</font></td>
   <td colspan=10 class=xl63>Reserved</td>
-  <td colspan=5 class=xl63>Hop Max Length</td>
+  <td colspan=5 class=xl63>Per-hop Metadata Length = <font color="red">3</font></td>
   <td colspan=8 class=xl63>Remaining Hop Cnt</td>
  </tr>
  <tr height=21 style='height:16.0pt'>
-  <td colspan=16 height=21 class=xl66 style='height:16.0pt'>Instruction Bitmap</td>
+  <td colspan=16 height=21 class=xl66 style='height:16.0pt'>Instruction Bitmap = <font color="red">1000000011000000</font></td>
   <td colspan=16 class=xl63>Reserved</td>
  </tr>
  <tr height=21 style='height:16.0pt'>

--- a/docs/int_header/INT_header.md
+++ b/docs/int_header/INT_header.md
@@ -1,57 +1,57 @@
-# Transparent Secuirty INT header reference definition
+# Transparent Security INT header reference definition
 
-The INT header is an L3 wrapper containing in band network telemetry.
+The INT header is an L3 wrapper containing in-band network telemetry.
 
-These definitions contains modifications and required fields for Transpaerent Secuirty.
+These definitions contain modifications and required fields for Transparent Security.
 
   Note: This version of the document is still under discussion and may change.
 
 This header heavily leverages the P4 INT header.  The changes and subset that are required for
 Transparent Security noted in this document.
 
-The current draft of theh 2.0 INT header document is located at [INT.pdf](https://github.com/p4lang/p4-applications/blob/master/docs/INT.pdf)
+The current draft of the 2.0 INT header document is located at [INT.pdf](https://github.com/p4lang/p4-applications/blob/master/docs/INT.pdf)
 
 ## Overview
 
 The INT IP shim header and the INT header(s) will be inserted after the IP header and before the datagram for IPv4 and will be a part of the extended header for IPv6.  The IP header will be updated to indicate that it has an INT header.
 
-The INT header is defined in two portions.  One is the Header for the INT metadata and the second is the actual metadata.  For both of these, we follow the INT specification with the addition of two bitmasks.  This additional value, an 8 octctet value for the originating device ID will be proposed to be added to the INT specification.
+The INT header is defined in two portions.  One is the Header for the INT metadata and the second is the actual metadata.  For both of these, we follow the INT specification with the addition of two bitmasks.  This additional value, an 8 octet value for the originating device ID will be proposed to be added to the INT specification.
 
-Please reffer to the 2.0 draft or release version of the P4 Application for the metadata header format.  This document includes the definition of the additional metadata types for the origionating device and a proposed IP shim.
+Please refer to the 2.0 draft or release version of the P4 Application for the metadata header format.  This document includes the definition of the additional metadata types for the originating device and a proposed IP shim.
 
-The other shim types, including UDP/TCP can also be used with the probe marker and not the differentiated service bit (DSCP), but those do not cover the range of IP traffic that is used in DDoS attacks.
+The other shim types, including UDP/TCP, can also be used with the probe marker and not the differentiated service bit (DSCP), but those do not cover the range of IP traffic that is used in DDoS attacks.
 
 ## IP Header update
 
 ### Encapsulation
 
-We want to preserve the routing and other information on the packet, so we will modify the protocol (IPv4) / next header (IPv6), length and for IPv4 the header checksum.
+We want to preserve the routing and other information on the packet, so we will modify the protocol (IPv4) / next header (IPv6), length and IPv4 the header checksum.
 
-Define a new L3 protocol.  The protocol for the INT header will be 63 "Any local network", since the INT header should never be exposed outside of the service providers network.  There is no specification for protocol 63.
+Define a new L3 protocol.  The protocol for the INT header will be 63 "Any local network" since the INT header should never be exposed outside of the service providers network.  There is no specification for protocol 63.
 
 IPv4:
 
-* Update the total length to match the new size.
-* Set the protocol to the INT protocol number. 253
+* Update the total length to match the new size
+* Set the protocol to the INT protocol number
 * Update the header checksum
 
 IPv6:
 
-* Set the Next Header to be the identifier for an IPv6 extension header to the INT procol number.  If existing extension headers are in place, INT will prepend to the first extension header.
-* The INT header next header field will be the existing IPv6 next header value.
+* Set the Next Header to be the identifier for an IPv6 extension header to the INT protocol number.  If existing extension headers are in place, INT will prepend to the first extension header
+* The INT header next header field will be the existing IPv6 next header value
 * The Hdr Ext Len will be updated appropriately
 
 ### IP header shim (4 bytes)
 
-This shim shall be 4 bytes and include the origional protocl (IPv4) or next protol (IPv6) and the lenght of the INT meta data.
+This shim shall be 4 bytes and include the original protocol (IPv4) or next protocol (IPv6) and the length of the INT metadata.
 
-Type: (1 octect) This field indicates the type of INT Header following the shim header. Two Type values are used: one for the hop-by-hop header type and the other for the destination header type.
+Type: (1 octet) This field indicates the type of INT Header following the shim header. Two Type values are used: one for the hop-by-hop header type and the other for the destination header type.
 
-Reservered: (1 octect)
+Reserved: (1 octet)
 
-Length: (1 octect) This is the total length of INT metadata header, INT stack and the shim header in 4-byte words. A non-INT device may read this field and skip over INT headers.
+Length: (1 octet) This is the total length of INT metadata header, INT stack and the shim header in 4-byte words. A non-INT device may read this field and skip over INT headers.
 
-Protocol: (1 octect) If IP protocol / next header is used to indicate INT, this field optionally stores the original protocol / next header value. Otherwise, this field is reserved.
+Protocol: (1 octet) If IP protocol / next header is used to indicate INT, this field optionally stores the original protocol / next header value. Otherwise, this field is reserved.
 
 ### Decapsulation
 
@@ -64,28 +64,28 @@ The original protocol / next header will be restored and the size and checksum w
 The hop-by-hop INT header will follow the header as described in section 4.7. INT Hop-by-Hop Metadata Header Format in the current INT specification.
 
 * INT instructions are encoded as a bitmap in the 16 bit INT Instruction field and adds two new bits to include
-the MAC address of the origionating device:
+the MAC address of the originating device:
 
-  * Transparent Secuirty the following bits:
-  * bit0: 4 octect Switch ID which is unique accross the network
-  * bit8: Originating Device MAC (Most signifigant 4 octets)
-  * bit9: Originating Device MAC (Least signifigant 2 octets + 2 octets of 0 padding)
+  * Transparent Security the following bits:
+  * bit0: 4 octet Switch ID which is unique across the network
+  * bit8: Originating Device MAC (Most significant 4 octets)
+  * bit9: Originating Device MAC (Least significant 2 octets + 2 octets of 0 padding)
 
-### Per Hop INT Metadata record (12 bytes)
+### Per-Hop INT Metadata record (12 bytes)
 
 This metadata will only contain one record and will not be updated on subsequent hops.
 
 Each metadata record corresponds to a bit filed in the instruction set and is 4 octets long.
 
-* Switch ID: Unique identifier for the swtich (4 octets)
-* Originating Device MAC Most signifigant 4 octets (4 octets)
-* Originating Device MAC least signifigant 2 octets + 2 octets of reserved padding (4 octets)
+* Switch ID: Unique identifier for the switch (4 octets)
+* Originating Device MAC Most significant 4 octets (4 octets)
+* Originating Device MAC least significant 2 octets + 2 octets of reserved padding (4 octets)
 
-On the customer's gateway, the gateway enters it's ID as the switch ID and it inserts the originating devices MAC address.
+On the customer's gateway, the gateway enters its ID as the switch ID and it inserts the originating devices MAC address.
 
-If the INT header is created on a swtich inside the head end.  This occurs when a header is not adding on the customer premises.  Two entries are added, one for the gateway device.  In a DOCSIS network this is the cable modem.
+If the INT header is created on a switch inside the head end.  This occurs when a header is not added at the customer premises.  Two entries are added, one for the gateway device.  In a DOCSIS network, this is the cable modem.
 
-On subsequent hops where it isn't connected to the originating device or the originating device is not know, 0xFFFFFFFF be  will inserted in the two "Originating Device MAC" records.
+On subsequent hops where it isn't connected to the originating device or the originating device is not know, 0xFFFFFFFF will be inserted in the two "Originating Device MAC" records.
 
 ## Examples
 

--- a/docs/int_header/INT_header.md
+++ b/docs/int_header/INT_header.md
@@ -9,15 +9,13 @@ These definitions contains modifications and required fields for Transpaerent Se
 This header heavily leverages the P4 INT header.  The changes and subset that are required for
 Transparent Security noted in this document.
 
-The original header document is located at [INT-current-spec.pdf](https://p4.org/assets/INT-current-spec.pdf)
+The current draft of theh 2.0 INT header document is located at [INT.pdf](https://github.com/p4lang/p4-applications/blob/master/docs/INT.pdf)
 
 ## Overview
 
-The INT header(s) will be inserted between the IP header and the datagram for IPv4 and will be a part of the extended header for IPv6.  The IP header will be updated to indicate that it has an INT header.
+The INT IP shim header and the INT header(s) will be inserted after the IP header and before the datagram for IPv4 and will be a part of the extended header for IPv6.  The IP header will be updated to indicate that it has an INT header.
 
-The INT header is defined in two portions.  One is the Header for the INT metadata and the second is the actual metadata.
-
-There are two INT headers that will be used with Transparent Security.  One for the originating device on the customer premises and the second is for the network path (Switches and gateways).
+The INT header is defined in two portions.  One is the Header for the INT metadata and the second is the actual metadata.  For both of these, we follow the INT specification with the addition of two bitmasks.  This additional value, an 8 octctet value for the originating device ID will be proposed to be added to the INT specification.
 
 ## IP Header update
 
@@ -39,54 +37,47 @@ IPv6:
 * The INT header next header field will be the existing IPv6 next header value.
 * The Hdr Ext Len will be updated appropriately
 
+### IP header shim
+
+Need to develop and IP shim.  This shim shall be 4 bytes and include the origional protocl (IPv4) or next protol (IPv6) and the lenght of the INT meta data.
+
+Type: (1 octect) This field indicates the type of INT Header following the shim header. Two Type values are used: one for the hop-by-hop header type and the other for the destination header type.
+
+Reservered: (1 octect)
+
+Length: (1 octect) This is the total length of INT metadata header, INT stack and the shim header in 4-byte words. A non-INT device may read this field and skip over INT headers.
+
+Protocol: (1 octect) If IP protocol / next header is used to indicate INT, this field optionally stores the original protocol / next header value. Otherwise, this field is reserved.
+
 ### Decapsulation
 
-The original protocol / next header will be restored and the size and checksum will be recalculated as appropriate.
+The original protocol / next header will be restored and the size and checksum will be recalculated as appropriate.  The IP shim header and INT header are also removed.
 
 ## INT Header
 
 ### INT metadata header (64 bits)
 
-This format will be used for both the device INT header and the network path INT header.  The INT instruction bitmask will indicate which data will be used.
+The hop-by-hop INT header will follow the header as described in section 4.7. INT Hop-by-Hop Metadata Header Format in the current INT specification.
 
-* Each INT metadata header is 8B long and should be 0 when initialized
-  * Ver (2b): INT metadata header version. Should be zero for this version
-  * Rep (2b): Replication requested. Should be zero
-  * C (1b): Copy. Should be zero
-  * E (1b): Max Hop Count exceeded. Set to 1 for the device INT header and when the max hop count has been exceeded with the networking header.
-  * Reserved (4b): Always zero.
-* Instruction Count (5b): The number of instructions that are set (i.e., number of
-1’s) in the instruction bitmap. This is 00010 (decimal 2) for the default gateway INT header.  Can be changed to add additional data.
-* Max Hop Count (8b): 1 for the device INT header and configurable for the network header.
-* Total Hop Count (8b): The current hop count for the network header and 1 for the device header.
-* INT instructions are encoded as a bitmap in the 16 bit INT Instruction field: the first 8 bits
-corresponds to a specific standard metadata as specified in Section 3 of the P4 INT spec.  The 9th-11th are defined in the metadata section below.  For the device ID the default is 000000001100000000.  For the network INT header the bit mask would be 100000000000000000.   Additional metadata can be added for the network INT header for performance and additional use cases.
-  * bit0 (MSB): Switch ID
+* INT instructions are encoded as a bitmap in the 16 bit INT Instruction field:
+* Transparent Secuirty requires the bit0 (MSB): Switch ID and adds two new bits to include
+the MAC address of the origionating device.
   * bit8: Originating Device MAC (Most signifigant 4 octets)
   * bit9: Originating Device MAC (Least signifigant 2 octets + 2 octets of 0 padding)
-* Next header IPv6 / Protocol IPv4 (1 octect)  If this is the last INT (header before the data gram), this will be the initial protocol from the IP header.  If there are subsequent headers then this will be 63 to denote that another INT header is to follow.
-* Reservered (1 octets)
 
-### Device INT Metadata (96 bits)
-
-This section is deviating from the INT spec as we are removing the leading bit to indicate the last record.
+### INT Metadata record (96 bits)
 
 This metadata will only contain one record and will not be updated on subsequent hops.
 
 Each metadata record corresponds to a bit filed in the instruction set and is 4 octets long.
 
+* Switch ID: Unique identifier for the swtich (4 octets)
 * Originating Device MAC Most signifigant 4 octets (4 octets)
 * Originating Device MAC least signifigant 2 octets + 2 octets of padding (4 octets)
 
-### Network INT Metadata (32 bits per hop)
+On the customer's gateway, the gateway enters it's ID as the switch ID and it inserts the originating devices MAC address.
 
-This section is deviating from the INT spec as we are removing the leading bit to indicate the last record.
-
-This metadata will be updated with each consecutive hop, until the max hop count has been reached.  The additional hop information will be inserted between the INT metadata header and the metadata from the previous hop.
-
-Each metadata record corresponds to a bit filed in the instruction set and is 4 octets long.
-
-* Switch ID: Unique identifier for the swtich (4 octets)
+If the INT header is created on a swtich inside the head end.  This occurs when a header is not adding on the customer premises.  Two entries are added, one for the gateway device.  In a DOCSIS network this is the cable modem.
 
 ## Examples
 
@@ -178,23 +169,32 @@ Each metadata record corresponds to a bit filed in the instruction set and is 4 
   <td align=right>31</td>
  </tr>
  <tr height=21 style='height:16.0pt'>
+  <td height=42 class=xl65 style='height:32.0pt'>IP Shim</td>
+  <td colspan=8 class=xl63>Type</td>
+  <td colspan=8 class=xl63>Reserved</td>
+  <td colspan=8 class=xl63>Next Protocol</td>
+  <td colspan=8 class=xl63>Length</td>
+ </tr>
+ <tr height=21 style='height:16.0pt'>
   <td rowspan=2 height=42 class=xl65 style='height:32.0pt'>Header</td>
-  <td colspan=2 class=xl63>Ver</td>
+  <td colspan=4 class=xl63>Ver</td>
   <td colspan=2 class=xl63>Rep</td>
   <td>C</td>
   <td>E</td>
-  <td colspan=5 class=xl63>Reserved</td>
-  <td colspan=5 class=xl63>Instruction Count</td>
-  <td colspan=8 class=xl63>Max Hop Count</td>
-  <td colspan=8 class=xl63>Total Hop Count</td>
+  <td>M</td>
+  <td colspan=10 class=xl63>Reserved</td>
+  <td colspan=5 class=xl63>Hop Max Length</td>
+  <td colspan=8 class=xl63>Remaining Hop Cnt</td>
  </tr>
  <tr height=21 style='height:16.0pt'>
   <td colspan=16 height=21 class=xl66 style='height:16.0pt'>Instruction Bitmap</td>
-  <td colspan=8 class=xl67>Next Protocol</td>
-  <td colspan=8 class=xl63>Reserved</td>
+  <td colspan=16 class=xl63>Reserved</td>
  </tr>
  <tr height=21 style='height:16.0pt'>
-  <td rowspan=2 height=84 class=xl65 style='height:64.0pt'>INT Metadata</td>
+  <td rowspan=3 height=84 class=xl65 style='height:64.0pt'>INT Metadata</td>
+  <td colspan=32 height=21 class=xl67 style='height:16.0pt'>Switch ID</td>
+</tr>
+ <tr height=21 style='height:16.0pt'>
   <td colspan=32 height=21 class=xl67 style='height:16.0pt'>Originating Device
   MAC Most signifigant 4 octets<span style='mso-spacerun:yes'> </span></td>
  </tr>
@@ -202,114 +202,5 @@ Each metadata record corresponds to a bit filed in the instruction set and is 4 
   <td colspan=16 height=21 class=xl67 style='height:16.0pt'>Originating Device
   MAC least signifigant 2 octets</td>
   <td colspan=16 class=xl67>Reserved</td>
- </tr>
-</table>
-
-### Example table for a switch INT header
-
-<table border=0 cellpadding=0 cellspacing=0 width=1419 style='border-collapse:
- collapse;table-layout:fixed;width:1056pt'>
- <col width=171 style='mso-width-source:userset;mso-width-alt:5461;width:128pt'>
- <col width=39 span=16 style='mso-width-source:userset;mso-width-alt:1237;
- width:29pt'>
- <col width=39 style='mso-width-source:userset;mso-width-alt:1237;width:29pt'>
- <col width=39 span=15 style='mso-width-source:userset;mso-width-alt:1237;
- width:29pt'>
- <tr height=21 style='height:16.0pt'>
-  <td height=21 width=171 style='height:16.0pt;width:128pt'>Description</td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
-  <td width=39 style='width:29pt'></td>
- </tr>
- <tr height=21 style='height:16.0pt'>
-  <td height=21 style='height:16.0pt'>Octet</td>
-  <td colspan=8 class=xl64>0</td>
-  <td colspan=8 class=xl64>1</td>
-  <td colspan=8 class=xl64>2</td>
-  <td colspan=8 class=xl64>3</td>
- </tr>
- <tr height=21 style='height:16.0pt'>
-  <td height=21 style='height:16.0pt'>Bit</td>
-  <td align=right>0</td>
-  <td align=right>1</td>
-  <td align=right>2</td>
-  <td align=right>3</td>
-  <td align=right>4</td>
-  <td align=right>5</td>
-  <td align=right>6</td>
-  <td align=right>7</td>
-  <td align=right>8</td>
-  <td align=right>9</td>
-  <td align=right>10</td>
-  <td align=right>11</td>
-  <td align=right>12</td>
-  <td align=right>13</td>
-  <td align=right>14</td>
-  <td align=right>15</td>
-  <td align=right>16</td>
-  <td align=right>17</td>
-  <td align=right>18</td>
-  <td align=right>19</td>
-  <td align=right>20</td>
-  <td align=right>21</td>
-  <td align=right>22</td>
-  <td align=right>23</td>
-  <td align=right>24</td>
-  <td align=right>25</td>
-  <td align=right>26</td>
-  <td align=right>27</td>
-  <td align=right>28</td>
-  <td align=right>29</td>
-  <td align=right>30</td>
-  <td align=right>31</td>
- </tr>
- <tr height=21 style='height:16.0pt'>
-  <td rowspan=2 height=42 class=xl65 style='height:32.0pt'>Header</td>
-  <td colspan=2 class=xl63>Ver</td>
-  <td colspan=2 class=xl63>Rep</td>
-  <td>C</td>
-  <td>E</td>
-  <td colspan=5 class=xl63>Reserved</td>
-  <td colspan=5 class=xl63>Instruction Count</td>
-  <td colspan=8 class=xl63>Max Hop Count</td>
-  <td colspan=8 class=xl63>Total Hop Count</td>
- </tr>
- <tr height=21 style='height:16.0pt'>
-  <td colspan=16 height=21 class=xl66 style='height:16.0pt'>Instruction Bitmap</td>
-  <td colspan=8 class=xl67>Next Protocol</td>
-  <td colspan=8 class=xl63>Reserved</td>
- </tr>
- <tr height=21 style='height:16.0pt'>
-  <td rowspan=1 height=84 class=xl65 style='height:64.0pt'>INT Metadata</td>
-  <td colspan=32 height=21 class=xl67 style='height:16.0pt'>Switch ID</td>
  </tr>
 </table>


### PR DESCRIPTION
#### What does this PR do?
Leverages the latest P4 INT header.
Adds an IP shim.
Removes modifications of the INT metadata header.

#### Do you have any concerns with this PR?
Yes.  Needs further review from partners.

#### How can the reviewer verify this PR?
Read the document.

#### Any background context you want to provide?
It was pointed out that the "current-INT.pdf" from p4.org was several versions behind.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Issue #81 
- Does the documentation need an update?
The .pcap example and other code need to be updated.

- Does this add new dependencies?
No.

- Have you added unit or functional tests for this PR?
No