### PR TITLE
Allow Jenkins to run multiple automation jobs concurrently

### DIFF
--- a/automation/env-build/aws-inst.tf
+++ b/automation/env-build/aws-inst.tf
@@ -76,6 +76,6 @@ EOT
 resource "aws_ami_from_instance" "transparent-security-env-build" {
   depends_on = [null_resource.env_provision]
   count = var.create_ami == "yes" ? 1 : 0
-  name               = "transparent-security-env-build-${var.build_id}"
+  name = "transparent-security-env-build-${var.build_id}"
   source_instance_id = aws_instance.transparent-security-build-img.id
 }

--- a/automation/env-build/aws-security.tf
+++ b/automation/env-build/aws-security.tf
@@ -20,7 +20,7 @@ provider "aws" {
 
 # Note: Script will fail if another process is leveraging the same build_id
 resource "aws_security_group" "transparent-security-img-sg" {
-  name = "transparent-security-gateway-${var.build_id}"
+  name = "transparent-security-env-build-${var.build_id}"
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]

--- a/automation/p4/mininet/aws-inst.tf
+++ b/automation/p4/mininet/aws-inst.tf
@@ -15,7 +15,12 @@
 resource "aws_instance" "transparent-security-mininet-integration" {
   ami = var.mininet_ami
   instance_type = var.instance_type
-  key_name = aws_key_pair.transparent-security-mini-pk.key_name
+  key_name = aws_key_pair.transparent-security-pk.key_name
+
+  tags = {
+    Name = "transparent-security-transparent-security-${var.scenario_name}-${var.build_id}"
+  }
+
   security_groups = [aws_security_group.transparent-security-img-sg.name]
   associate_public_ip_address = true
 

--- a/automation/p4/mininet/aws-security.tf
+++ b/automation/p4/mininet/aws-security.tf
@@ -20,7 +20,7 @@ provider "aws" {
 
 # Note: Script will fail if another process is leveraging the same build_id
 resource "aws_security_group" "transparent-security-img-sg" {
-  name = "transparent-security-gateway-${var.build_id}"
+  name = "transparent-security-${var.scenario_name}-${var.build_id}"
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     from_port = 22
@@ -45,6 +45,6 @@ resource "aws_security_group" "transparent-security-img-sg" {
 }
 
 # AWS EC2 Instance Public Key
-resource "aws_key_pair" "transparent-security-mini-pk" {
+resource "aws_key_pair" "transparent-security-pk" {
   public_key = file(var.public_key_file)
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes #21 
Allows Jenkins to run all 5 different automation scripts concurrently. These changes were required as the security group name was being generated the same way within automation/p4/mininet
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
Verify with Jenkins that all tests (other than core at this point) are passing when run together.
#### Any background context you want to provide?
New issue found while configuring the Jenkins jobs
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes, Fixes #21 
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
