### PR TITLE
Removed run_mode from the scenario tests

### DIFF
--- a/automation/p4/mininet/scenarios.tf
+++ b/automation/p4/mininet/scenarios.tf
@@ -17,7 +17,7 @@ resource "null_resource" "transparent-security-run-senario-tests" {
   provisioner "remote-exec" {
     inline = [
       "sudo pip install ansible",
-      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_scenario_pb_dir}/${var.scenario_name}/${var.test_case}.yml --extra-vars='run_mode=${var.test_run_mode}'",
+      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_scenario_pb_dir}/${var.scenario_name}/${var.test_case}.yml",
     ]
   }
 

--- a/automation/p4/mininet/variables.tf
+++ b/automation/p4/mininet/variables.tf
@@ -55,8 +55,5 @@ variable "remote_scenario_pb_dir" {default = "/home/ubuntu/transparent-security/
 # Also supports "gateway", "aggregate", and "core"
 variable "scenario_name" {default = "full"}
 
-# Any other value will run the tests in local mode
-variable "test_run_mode" {default = "remote"}
-
 # Default test case that will execute the playbook located at ../../../playbooks/scenarios/<scenario_name>-<test_case>.yml
 variable "test_case" {default = "all"}

--- a/automation/p4/tofino/scenarios.tf
+++ b/automation/p4/tofino/scenarios.tf
@@ -11,13 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "null_resource" "transparent-security-run-senario-tests" {
+resource "null_resource" "transparent-security-run-scenario-tests" {
   depends_on = [null_resource.tps-tofino-setup-nodes]
 
   provisioner "remote-exec" {
     inline = [
       "sudo pip install ansible",
-      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_scenario_pb_dir}/${var.scenario_name}/${var.test_case}.yml --extra-vars='run_mode=remote'",
+      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_scenario_pb_dir}/${var.scenario_name}/${var.test_case}.yml --extra-vars='node_interface=eth0'",
     ]
   }
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -364,8 +364,7 @@ Note - The transparent-security.ini refers to the inventory file on the remote m
 - To use the sample scenario provided by CableLabs, run the following command on the remote VM -
 ```bash
 export ANSIBLE_HOST_KEY_CHECKING=False
-# run_mode denotes whether to run the tests on the localhost (faster packet generation) or directly on the mininet hosts (more accurate architecture but slow)
-ansible-playbook -u ubuntu -i transparent-security.ini transparent-security/playbooks/scenarios/full/all.yml --extra-vars="run_mode=<'remote'|'local')>
+ansible-playbook -u ubuntu -i transparent-security.ini transparent-security/playbooks/scenarios/full/all.yml
 ```
 Note - Refer the Wiki page [Attack Scenario](https://github.com/cablelabs/transparent-security/wiki/2.-Attack-Scenario) for a 
 detailed explanation of the attack scenario.
@@ -455,8 +454,7 @@ Note - The transparent-security.ini refers to the inventory file on the remote m
 - To use the sample scenario provided by CableLabs, run the following command on the remote VM -
 ```bash
 export ANSIBLE_HOST_KEY_CHECKING=False
-# run_mode denotes whether to run the tests on the localhost (faster packet generation) or directly on the mininet hosts (more accurate architecture but slow)
-ansible-playbook -u ubuntu -i transparent-security.ini transparent-security/playbooks/scenarios/full/all.yml --extra-vars="run_mode=<'remote'|'local')>
+ansible-playbook -u ubuntu -i transparent-security.ini transparent-security/playbooks/scenarios/full/all.yml
 ```
 Note - Refer the Wiki page [Attack Scenario](https://github.com/cablelabs/transparent-security/wiki/2.-Attack-Scenario) for a 
 detailed explanation of the attack scenario.

--- a/playbooks/scenarios/aggregate/data-forward.yml
+++ b/playbooks/scenarios/aggregate/data-forward.yml
@@ -23,13 +23,11 @@
     switch: "{{ topo_dict.switches.aggregate }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host  }}"
     sender: "{{ topo_dict.hosts.host1 }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts.host2 }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
 
 # Basic Data Forward scenario for INT UDP Packets without a data-inspection table entry so the original simply passes through
@@ -41,13 +39,11 @@
     switch: "{{ topo_dict.switches.aggregate }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     # For sending INT packets on the #1 of 3 send/receive iteration
     sr_data_inspection_int:

--- a/playbooks/scenarios/aggregate/data-inspection.yml
+++ b/playbooks/scenarios/aggregate/data-inspection.yml
@@ -23,13 +23,11 @@
     switch: "{{ topo_dict.switches.aggregate }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     data_inspection_table_action:
       control_name: TpsAggIngress

--- a/playbooks/scenarios/core/data-forward.yml
+++ b/playbooks/scenarios/core/data-forward.yml
@@ -22,13 +22,11 @@
     switch: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
 
 # Basic Data Forward scenario for INT packets to egress port
@@ -40,13 +38,11 @@
     switch: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     sr_data_inspection_int:
       - switch_id: 1002
@@ -63,13 +59,11 @@
     switch: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: clone
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth3' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     sr_data_inspection_int:
       - switch_id: 1002

--- a/playbooks/scenarios/core/data-inspection.yml
+++ b/playbooks/scenarios/core/data-inspection.yml
@@ -22,13 +22,11 @@
     switch: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: clone
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts.host2 }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth3' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     data_inspection_table_action:
       control_name: TpsCoreIngress
@@ -60,13 +58,11 @@
     switch: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     data_inspection_table_action:
       control_name: TpsCoreIngress

--- a/playbooks/scenarios/full/packet-flood.yml
+++ b/playbooks/scenarios/full/packet-flood.yml
@@ -13,7 +13,8 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Sending 25 packets within a second 1x through gateway 1
+# Sending 150 packets within a second 2x through gateway 1.
+# The second set should be dropped else this will fail
 - import_playbook: ../test_cases/send_receive.yml
   vars:
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
@@ -24,13 +25,11 @@
     remote_send_host: Camera1
     remote_rec_host: inet
     switch: "{{ topo_dict.switches[switch_name] }}"
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     dst_mac: "{{ sender['switch_mac'] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch_name }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % core_switch_name }}"
     receiver_log_filename: "udp-flood-receiver-{{ rec_host }}-{{ send_protocol }}-1.out"
     sender_log_filename: "udp-flood-sender-{{ send_host }}-{{ send_protocol }}-1.out"
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 1) }}"
@@ -42,7 +41,8 @@
     send_loop_delay: 5
     sdn_host_port: "{{ sdn_ip }}:{{ sdn_port }}"
 
-# Sending 50 packets within a second 1x through gateway 2
+# Sending 150 packets within a second 2x through gateway 2.
+# The second set should be dropped else this will fail
 - import_playbook: ../test_cases/send_receive.yml
   vars:
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
@@ -53,13 +53,11 @@
     remote_send_host: Camera2
     remote_rec_host: inet
     switch: "{{ topo_dict.switches[switch_name] }}"
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     dst_mac: "{{ sender['switch_mac'] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch_name }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % core_switch_name }}"
     receiver_log_filename: "udp-flood-receiver-{{ rec_host }}-{{ send_protocol }}-2.out"
     sender_log_filename: "udp-flood-sender-{{ send_host }}-{{ send_protocol }}-2.out"
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 3) }}"
@@ -83,13 +81,11 @@
     remote_send_host: Camera3
     remote_rec_host: inet
     switch: "{{ topo_dict.switches[switch_name] }}"
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     dst_mac: "{{ sender['switch_mac'] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch_name }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % core_switch_name }}"
     receiver_log_filename: "udp-flood-receiver-{{ rec_host }}-{{ send_protocol }}-3.out"
     sender_log_filename: "udp-flood-sender-{{ send_host }}-{{ send_protocol }}-3.out"
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 5) }}"

--- a/playbooks/scenarios/gateway/data-drop.yml
+++ b/playbooks/scenarios/gateway/data-drop.yml
@@ -23,14 +23,12 @@
     switch: "{{ topo_dict.switches.gateway }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     send_port: 4321
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     data_drop_table_action:
       control_name: TpsGwIngress

--- a/playbooks/scenarios/gateway/data-forward.yml
+++ b/playbooks/scenarios/gateway/data-forward.yml
@@ -23,11 +23,9 @@
     switch: "{{ topo_dict.switches.gateway }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"

--- a/playbooks/scenarios/gateway/data-inspection.yml
+++ b/playbooks/scenarios/gateway/data-inspection.yml
@@ -23,13 +23,11 @@
     switch: "{{ topo_dict.switches.gateway }}"
     remote_send_host: host1
     remote_rec_host: host2
-    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     data_inspection_table_action:
       control_name: TpsGwIngress

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -21,6 +21,7 @@
     receive_timeout: "{{ receiver_timeout_seconds | default(60) }}"
     hops: "{{ int_hops | default(0) }}"
     ip_ver: "{{ ip_version | default('4') }}"
+    receiver_intf: "{{ node_interface | default('%s-eth0' % rec_host ) }}"
     receiver_log_file: "{{ host_log_dir }}/{{ receiver_log_filename }}"
   tasks:
     - debug:
@@ -72,6 +73,7 @@
     loops: "{{ send_loops | default(1) }}"
     loop_delay: "{{ send_loop_delay | default(0) }}"
     hops: "{{ int_hops | default(0) }}"
+    sender_intf: "{{ node_interface | default('%s-eth0' % send_host ) }}"
     sender_log_file: "{{ host_log_dir }}/{{ sender_log_filename }}"
     protocol: "{{ send_protocol | default('UDP') }}"
     int_hdr_df: "{{ host_log_dir }}/send_int_data-ip-{{ ip_ver }}-proto-{{ protocol }}-ih-{{ hops }}.yml"

--- a/playbooks/tofino/bf-sde/bf-sde-build.yml
+++ b/playbooks/tofino/bf-sde/bf-sde-build.yml
@@ -37,7 +37,7 @@
         $SDE_INSTALL/lib/python3.4/*
         /usr/local/lib/python{{ python_version }}/dist-packages/
 
-    - name: Copy built python tofino libs to Python {{ python_version }} runtime
+    - name: Copy built python tofino libs to Python 2.7 runtime
       shell: >
         sudo cp -r
         $SDE_INSTALL/lib/python2.7/site-packages/*


### PR DESCRIPTION
#### What does this PR do?
Fixes #183 
Removes the run_mode optimization hook to execute the tests on the mininet host using the bridge interfaces rather than running the command directly on the mininet host.
#### Do you have any concerns with this PR?
no because this actually simplifies the scenario testing
#### How can the reviewer verify this PR?
Run the automation scripts and the var 'run_mode' will no longer matter
#### Any background context you want to provide?
Shell commands no longer have the 40-60 second latency before the execution so run_mode is obsolete and could potentially mask other issues
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? updated
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
