### PR TITLE
Added /dataForward RESTful SDN endpoint

### DIFF
--- a/playbooks/scenarios/aggregate/data-forward.yml
+++ b/playbooks/scenarios/aggregate/data-forward.yml
@@ -30,19 +30,14 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_forward_table_action:
-      control_name: TpsAggIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
 
 # Basic Data Forward scenario for INT UDP Packets without a data-inspection table entry so the original simply passes through
 - import_playbook: ../general/data_forward_basic.yml
@@ -65,16 +60,11 @@
       - switch_id: 1001
         orig_mac: "{{ sender.mac }}"
     sr_rec_int_hops: 2
-    data_forward_table_action:
-      control_name: TpsAggIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201

--- a/playbooks/scenarios/aggregate/data-inspection.yml
+++ b/playbooks/scenarios/aggregate/data-inspection.yml
@@ -28,19 +28,14 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_forward_table_action:
-      control_name: TpsAggIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
     data_inspection_table_action:
       control_name: TpsAggIngress
       table_name: data_inspection_t

--- a/playbooks/scenarios/core/data-forward.yml
+++ b/playbooks/scenarios/core/data-forward.yml
@@ -29,19 +29,14 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_forward_table_action:
-      control_name: TpsCoreIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
 
 # Basic Data Forward scenario for INT packets to egress port
 - import_playbook: ../general/data_forward_basic.yml
@@ -64,19 +59,14 @@
       - switch_id: 1001
         orig_mac: "{{ sender.mac }}"
     sr_rec_int_hops: 0
-    data_forward_table_action:
-      control_name: TpsCoreIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
 
 # Basic Data Forward scenario for INT packets to clone port
 - import_playbook: ../general/data_forward_basic.yml
@@ -99,16 +89,11 @@
       - switch_id: 1001
         orig_mac: "{{ sender.mac }}"
     sr_rec_int_hops: 2
-    data_forward_table_action:
-      control_name: TpsCoreIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201

--- a/playbooks/scenarios/core/data-inspection.yml
+++ b/playbooks/scenarios/core/data-inspection.yml
@@ -29,19 +29,14 @@
     receiver: "{{ topo_dict.hosts.host2 }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_forward_table_action:
-      control_name: TpsCoreIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
     data_inspection_table_action:
       control_name: TpsCoreIngress
       table_name: data_inspection_t
@@ -79,19 +74,14 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_forward_table_action:
-      control_name: TpsCoreIngress
-      table_name: data_forward_t
-      action:
-        name: data_forward
-        match_fields:
-          - key: hdr.ethernet.dst_mac
-            value:
-              - "{{ receiver.mac }}"
-              - "{{ 48 }}"
-        params:
-          - key: port
-            value: 2
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
     data_inspection_table_action:
       control_name: TpsCoreIngress
       table_name: data_inspection_t

--- a/playbooks/scenarios/gateway/data-drop.yml
+++ b/playbooks/scenarios/gateway/data-drop.yml
@@ -30,6 +30,14 @@
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
     attack:
       url: "http://{{ sdn_ip }}:{{ sdn_port }}/gwAttack"
       body:

--- a/playbooks/scenarios/gateway/data-forward.yml
+++ b/playbooks/scenarios/gateway/data-forward.yml
@@ -27,3 +27,11 @@
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201

--- a/playbooks/scenarios/gateway/data-inspection.yml
+++ b/playbooks/scenarios/gateway/data-inspection.yml
@@ -29,6 +29,14 @@
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201
     data_inspection_table_action:
       control_name: TpsGwIngress
       table_name: data_inspection_t

--- a/playbooks/scenarios/general/data_forward_basic.yml
+++ b/playbooks/scenarios/general/data_forward_basic.yml
@@ -13,15 +13,25 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Add table entry to "{{ data_forward_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
+# Add table entry to data_forward_t table
+- hosts: "{{ rec_host }}"
+  gather_facts: no
   vars:
-    int_hops: "{{ sr_rec_int_hops | default(0) }}"
-    te_conf_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_forward_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
     execute_insert: "{{ write_data_forward | default(False) }}"
+  tasks:
+    - block:
+      - name: Data forward structure
+        debug:
+          var: data_forward
+
+      - name: Insert data forward table entry via endpoint {{ data_forward.url }}
+        uri:
+          url: "{{ data_forward.url }}"
+          method: POST
+          body_format: "{{ data_forward.body_format | default('json') }}"
+          body: "{{ data_forward.body }}"
+          status_code: "{{ data_forward.ok_status | default('200') }}"
+      when: execute_insert|bool
 
 ## Sending UDP packets expect all to be received
 - import_playbook: ../test_cases/send_receive.yml
@@ -35,13 +45,17 @@
     inspection_data: "{{ sr_data_inspection_int | default(None) }}"
     max_received_packet_count: "{{ send_packet_count }}"
 
-# Delete table entry from "{{ data_forward_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
+# Delete table entry from data_forward_t table
+- hosts: "{{ rec_host }}"
+  gather_facts: no
   vars:
-    int_hops: "{{ sr_rec_int_hops | default(0) }}"
-    te_conf_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_forward_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
-    p4_te_insert: False
     execute_insert: "{{ write_data_forward | default(False) }}"
+  tasks:
+    - name: Delete data forward table entry via endpoint {{ data_forward.url }}
+      uri:
+        url: "{{ data_forward.url }}"
+        method: DELETE
+        body_format: "{{ data_forward.body_format | default('json') }}"
+        body: "{{ data_forward.body }}"
+        status_code: "{{ data_forward.ok_status | default('200') }}"
+      when: execute_insert|bool

--- a/playbooks/scenarios/lab_trial/data-forward.yml
+++ b/playbooks/scenarios/lab_trial/data-forward.yml
@@ -26,3 +26,11 @@
     sender: "{{ topo_dict.hosts[send_host] }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
     dst_mac: "{{ receiver.mac }}"
+    data_forward:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+      body:
+        device_id: "{{ switch.id }}"
+        switch_mac: "{{ switch.mac }}"
+        dst_mac: "{{ receiver.mac }}"
+        output_port: 2
+      ok_status: 201

--- a/playbooks/scenarios/single_switch/data_drop_basic.yml
+++ b/playbooks/scenarios/single_switch/data_drop_basic.yml
@@ -13,15 +13,20 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Add table entry to "{{ data_forward_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
+# Add table entry to data_forward_t table
+- hosts: "{{ rec_host }}"
+  gather_facts: no
   vars:
-    int_hops: "{{ sr_rec_int_hops | default(0) }}"
-    te_conf_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_forward_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
     execute_insert: "{{ write_data_forward | default(False) }}"
+  tasks:
+    - name: Insert data forward table entry via endpoint {{ data_forward.url }}
+      uri:
+        url: "{{ data_forward.url }}"
+        method: POST
+        body_format: "{{ data_forward.body_format | default('json') }}"
+        body: "{{ data_forward.body }}"
+        status_code: "{{ data_forward.ok_status | default('200') }}"
+      when: execute_insert|bool
 
 # Sending UDP packets expect all to be received
 - import_playbook: ../test_cases/send_receive.yml
@@ -84,13 +89,17 @@
     inspection_data: "{{ sr3_data_inspection_int | default(None) }}"
     max_received_packet_count: "{{ send_packet_count }}"
 
-# Delete table entry from "{{ data_forward_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
+# Delete table entry from data_forward_t table
+- hosts: "{{ rec_host }}"
+  gather_facts: no
   vars:
-    int_hops: "{{ sr_rec_int_hops | default(0) }}"
-    te_conf_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_forward_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
-    p4_te_insert: False
     execute_insert: "{{ write_data_forward | default(False) }}"
+  tasks:
+    - name: Insert data forward table entry via endpoint {{ data_forward.url }}
+      uri:
+        url: "{{ data_forward.url }}"
+        method: DELETE
+        body_format: "{{ data_forward.body_format | default('json') }}"
+        body: "{{ data_forward.body }}"
+        status_code: "{{ data_forward.ok_status | default('200') }}"
+      when: execute_insert|bool

--- a/playbooks/scenarios/single_switch/data_inspection_basic.yml
+++ b/playbooks/scenarios/single_switch/data_inspection_basic.yml
@@ -13,15 +13,20 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Add table entry to "{{ data_forward_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
+# Add table entry to data_forward_t table
+- hosts: "{{ rec_host }}"
+  gather_facts: no
   vars:
-    int_hops: "{{ sr_rec_int_hops | default(0) }}"
-    te_conf_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_forward_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
     execute_insert: "{{ write_data_forward | default(False) }}"
+  tasks:
+    - name: Insert data forward table entry via endpoint {{ data_forward.url }}
+      uri:
+        url: "{{ data_forward.url }}"
+        method: POST
+        body_format: "{{ data_forward.body_format | default('json') }}"
+        body: "{{ data_forward.body }}"
+        status_code: "{{ data_forward.ok_status | default('200') }}"
+      when: execute_insert|bool
 
 # Add table entry to "{{ data_inspection_table }}"
 - import_playbook: ../test_cases/write_to_p4_table.yml
@@ -69,13 +74,17 @@
     inspection_data: "{{ sr2_data_inspection_int | default(None) }}"
     max_received_packet_count: "{{ send_packet_count }}"
 
-# Delete table entry from "{{ data_forward_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
+- hosts: "{{ rec_host }}"
+  gather_facts: no
   vars:
-    int_hops: "{{ sr_rec_int_hops | default(0) }}"
-    te_conf_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_forward_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "df-write-data-forward-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
-    p4_te_insert: False
     execute_insert: "{{ write_data_forward | default(False) }}"
+  tasks:
+    - name: Delete data forward table entry via endpoint {{ data_forward.url }}
+      uri:
+        url: "{{ data_forward.url }}"
+        method: DELETE
+        body_format: "{{ data_forward.body_format | default('json') }}"
+        body: "{{ data_forward.body }}"
+        status_code: "{{ data_forward.ok_status | default('200') }}"
+      when: execute_insert|bool
+

--- a/trans_sec/bfruntime_lib/bfrt_switch.py
+++ b/trans_sec/bfruntime_lib/bfrt_switch.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import logging
-import struct
 from abc import ABC
 from threading import Thread
 
@@ -59,7 +58,7 @@ class BFRuntimeSwitch(SwitchConnection, ABC):
                         action_params, ingress_class=True):
         raise NotImplementedError
 
-    def add_data_forward(self, source_mac, ingress_port):
+    def add_data_forward(self, dst_mac, egress_port):
         raise NotImplementedError
 
     def build_device_config(self):

--- a/trans_sec/controller/core_controller.py
+++ b/trans_sec/controller/core_controller.py
@@ -89,7 +89,7 @@ class CoreController(AbstractController):
         else:
             logger.info('Not inserting anything to data_inspection_t')
 
-        logger.info('Completed rules for device [%s]', sw.sw_info['mac'])
+        logger.info('Completed rules for device [%s]', sw.mac)
 
     @staticmethod
     def __make_int_rules(sw):

--- a/trans_sec/controller/ddos_sdn_controller.py
+++ b/trans_sec/controller/ddos_sdn_controller.py
@@ -64,6 +64,37 @@ class DdosSdnController:
             controller.make_switch_rules(add_di)
         logger.debug('Switch rule creation completed')
 
+    def add_data_forward(self, df_req):
+        """
+        Adds a data forward table entry into the expected switch
+        """
+        self.__data_forward(df_req)
+
+    def del_data_forward(self, df_req):
+        """
+        Adds a data forward table entry into the expected switch
+        """
+        self.__data_forward(df_req, True)
+
+    def __data_forward(self, df_req, del_flag=False):
+        """
+        Removes a device to mitigate an attack
+        """
+        logger.debug('df_req - [%s]', df_req)
+        for key, controller in self.controllers.items():
+            for switch in controller.switches:
+                logger.debug('switch - [%s]', switch.device_id)
+                if switch.device_id == df_req['device_id']:
+                    if del_flag:
+                        switch.del_data_forward(df_req['dst_mac'])
+                    else:
+                        switch.add_data_forward(df_req['dst_mac'],
+                                                df_req['output_port'])
+                    return
+
+        logger.warning('Could not find switch with device_id - [%s]',
+                       df_req['device_id'])
+
     def remove_attacker(self, attack):
         """
         Removes a device to mitigate an attack

--- a/trans_sec/p4runtime_lib/core_switch.py
+++ b/trans_sec/p4runtime_lib/core_switch.py
@@ -48,22 +48,22 @@ class CoreSwitch(P4RuntimeSwitch):
         super(self.__class__, self).write_multicast_entry(hosts)
         self.write_arp_flood()
 
-    def add_data_forward(self, source_mac, ingress_port):
+    def add_data_forward(self, dst_mac, egress_port):
         logger.info(
             'Adding data forward to core device [%s] with source_mac '
             '- [%s] and ingress port - [%s]',
-            self.device_id, source_mac, ingress_port)
+            self.device_id, dst_mac, egress_port)
         inserted = super(self.__class__, self).add_data_forward(
-            source_mac, ingress_port)
+            dst_mac, egress_port)
 
         if inserted:
             table_entry = self.p4info_helper.build_table_entry(
                 table_name='{}.arp_forward_t'.format(self.p4_ingress),
                 match_fields={
-                    'hdr.ethernet.dst_mac': source_mac
+                    'hdr.ethernet.dst_mac': dst_mac
                 },
                 action_name='{}.arp_forward'.format(self.p4_ingress),
-                action_params={'port': ingress_port}
+                action_params={'port': egress_port}
             )
             self.write_table_entry(table_entry)
 

--- a/trans_sec/switch.py
+++ b/trans_sec/switch.py
@@ -32,6 +32,7 @@ class SwitchConnection(object):
     def __init__(self, sw_info):
         self.sw_info = sw_info
         self.name = sw_info['name']
+        self.mac = sw_info['mac']
         self.type = sw_info['type']
         self.device_id = sw_info['id']
         self.grpc_addr = sw_info['grpc']
@@ -134,7 +135,11 @@ class SwitchConnection(object):
                                 election_low=election_low)
 
     @abstractmethod
-    def add_data_forward(self, source_mac, ingress_port):
+    def add_data_forward(self, dst_mac, egress_port):
+        raise NotImplemented
+
+    @abstractmethod
+    def del_data_forward(self, dst_mac):
         raise NotImplemented
 
     @abstractmethod


### PR DESCRIPTION


data_forward_t table entries (currently working with gateway and aggregate on mininet and tofino)
core.p4 is returning StatusCode.PERMISSION_DENIED/"Not master" after the initial record is inserted then deleted

#### What does this PR do?
Allows one to insert/delete records to/from the data_forward_t table

Fixes #220 
#### Do you have any concerns with this PR?
Only one but it is currently immaterial. When running against core on mininet and configured to insert rather than learn the forward paths, I am getting permission errors that I am not observing on aggregate. Please see issue #225 
#### How can the reviewer verify this PR?
Ensure CI hasn't broken
#### Any background context you want to provide?
Feature should give us better flexibility and code simplification.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no, updated a few to exercise the changes.
