### PR TITLE
Data inspection ws

### DIFF
--- a/p4/aggregate/aggregate.p4
+++ b/p4/aggregate/aggregate.p4
@@ -110,7 +110,7 @@ control TpsAggIngress(inout headers hdr,
 
     action data_inspect_packet_ipv6() {
         hdr.ipv6.next_hdr_proto = TYPE_UDP;
-        /* hdr.int_shim.next_proto = hdr.ipv6.next_hdr_proto; */
+        hdr.int_shim.next_proto = hdr.ipv6.next_hdr_proto;
         #ifdef BMV2
         hdr.ipv6.payload_len = hdr.ipv6.payload_len + IPV6_HDR_BYTES + ((bit<16>)hdr.int_shim.length * BYTES_PER_SHIM * INT_SHIM_HOP_SIZE) + UDP_HDR_BYTES;
         #endif
@@ -204,9 +204,7 @@ control TpsAggIngress(inout headers hdr,
                 add_switch_id_t.apply();
             }
             else {
-                if (hdr.ipv4.isValid() || hdr.ipv6.isValid()) {
-                    data_inspection_t.apply();
-                }
+                data_inspection_t.apply();
                 if (hdr.int_shim.isValid()) {
                     if (hdr.ipv4.isValid()) {
                         data_inspect_packet_ipv4();

--- a/p4/core/core.p4
+++ b/p4/core/core.p4
@@ -163,9 +163,7 @@ control TpsCoreIngress(inout headers hdr,
         } else if (standard_metadata.egress_spec != DROP_PORT) {
             if (IS_NORMAL(standard_metadata)) {
                 // First pass
-                if (hdr.ipv4.isValid() || hdr.ipv6.isValid()) {
-                    data_inspection_t.apply();
-                }
+                data_inspection_t.apply();
                 recirculate_packet();
             } else if (IS_RECIRCULATED(standard_metadata)) {
                 // second pass

--- a/p4/core/core.p4
+++ b/p4/core/core.p4
@@ -163,7 +163,9 @@ control TpsCoreIngress(inout headers hdr,
         } else if (standard_metadata.egress_spec != DROP_PORT) {
             if (IS_NORMAL(standard_metadata)) {
                 // First pass
-                data_inspection_t.apply();
+                if (hdr.ipv4.isValid() || hdr.ipv6.isValid()) {
+                    data_inspection_t.apply();
+                }
                 recirculate_packet();
             } else if (IS_RECIRCULATED(standard_metadata)) {
                 // second pass

--- a/p4/gateway/gateway.p4
+++ b/p4/gateway/gateway.p4
@@ -316,9 +316,8 @@ control TpsGwIngress(inout headers hdr,
             generate_learn_notification();
         }
         else if (standard_metadata.egress_spec != DROP_PORT) {
-            if (hdr.ipv4.isValid() || hdr.ipv6.isValid()) {
-                data_inspection_t.apply();
-            }
+            data_inspection_t.apply();
+
             if (hdr.int_shim.isValid()) {
                 if (hdr.ipv4.isValid()) {
                     data_inspect_packet_ipv4();

--- a/playbooks/scenarios/aggregate/data-forward.yml
+++ b/playbooks/scenarios/aggregate/data-forward.yml
@@ -30,14 +30,14 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_forward:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-      body:
-        device_id: "{{ switch.id }}"
-        switch_mac: "{{ switch.mac }}"
-        dst_mac: "{{ receiver.mac }}"
-        output_port: 2
-      ok_status: 201
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201
 
 # Basic Data Forward scenario for INT UDP Packets without a data-inspection table entry so the original simply passes through
 - import_playbook: ../general/data_forward_basic.yml
@@ -60,11 +60,11 @@
       - switch_id: 1001
         orig_mac: "{{ sender.mac }}"
     sr_rec_int_hops: 2
-    data_forward:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-      body:
-        device_id: "{{ switch.id }}"
-        switch_mac: "{{ switch.mac }}"
-        dst_mac: "{{ receiver.mac }}"
-        output_port: 2
-      ok_status: 201
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201

--- a/playbooks/scenarios/aggregate/data-inspection.yml
+++ b/playbooks/scenarios/aggregate/data-inspection.yml
@@ -36,19 +36,10 @@
         dst_mac: "{{ receiver.mac }}"
         output_port: 2
       ok_status: 201
-    data_inspection_table_action:
-      control_name: TpsAggIngress
-      table_name: data_inspection_t
-      action:
-        name: "{{ 'data_inspect_packet' }}"
-        match_fields:
-          - key: hdr.ethernet.src_mac
-            value: "{{ sender.mac }}"
-          - key: hdr.ethernet.etherType
-            value: "{{ '0x0800' if ip_version == '4' else '0x86dd' }}"
-        params:
-          - key: device
-            value: "{{ sender.id }}"
-          - key: switch_id
-            value: "{{ switch.id }}"
+    data_inspection:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
     sr1_rec_int_hops: 1

--- a/playbooks/scenarios/core/data-forward.yml
+++ b/playbooks/scenarios/core/data-forward.yml
@@ -29,14 +29,14 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_forward:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-      body:
-        device_id: "{{ switch.id }}"
-        switch_mac: "{{ switch.mac }}"
-        dst_mac: "{{ receiver.mac }}"
-        output_port: 2
-      ok_status: 201
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201
 
 # Basic Data Forward scenario for INT packets to egress port
 - import_playbook: ../general/data_forward_basic.yml
@@ -59,14 +59,14 @@
       - switch_id: 1001
         orig_mac: "{{ sender.mac }}"
     sr_rec_int_hops: 0
-    data_forward:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-      body:
-        device_id: "{{ switch.id }}"
-        switch_mac: "{{ switch.mac }}"
-        dst_mac: "{{ receiver.mac }}"
-        output_port: 2
-      ok_status: 201
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201
 
 # Basic Data Forward scenario for INT packets to clone port
 - import_playbook: ../general/data_forward_basic.yml
@@ -90,10 +90,10 @@
         orig_mac: "{{ sender.mac }}"
     sr_rec_int_hops: 2
     data_forward:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-      body:
-        device_id: "{{ switch.id }}"
-        switch_mac: "{{ switch.mac }}"
-        dst_mac: "{{ receiver.mac }}"
-        output_port: 2
-      ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201

--- a/playbooks/scenarios/core/data-inspection.yml
+++ b/playbooks/scenarios/core/data-inspection.yml
@@ -37,17 +37,12 @@
         dst_mac: "{{ receiver.mac }}"
         output_port: 2
       ok_status: 201
-    data_inspection_table_action:
-      control_name: TpsCoreIngress
-      table_name: data_inspection_t
-      action:
-        name: data_inspect_packet
-        match_fields:
-          - key: hdr.udp_int.dst_port
-            value: 555
-        params:
-          - key: switch_id
-            value: "{{ switch.id }}"
+    data_inspection:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
     # For sending INT packets on the #1 of 3 send/receive iteration
     sr1_data_inspection_int:
       - switch_id: 1002
@@ -82,17 +77,12 @@
         dst_mac: "{{ receiver.mac }}"
         output_port: 2
       ok_status: 201
-    data_inspection_table_action:
-      control_name: TpsCoreIngress
-      table_name: data_inspection_t
-      action:
-        name: data_inspect_packet
-        match_fields:
-          - key: hdr.udp_int.dst_port
-            value: 555
-        params:
-          - key: switch_id
-            value: "{{ switch.id }}"
+    data_inspection:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
     # For sending INT packets on the #1 of 3 send/receive iteration
     sr1_data_inspection_int:
       - switch_id: 1002

--- a/playbooks/scenarios/gateway/data-forward.yml
+++ b/playbooks/scenarios/gateway/data-forward.yml
@@ -27,11 +27,11 @@
     send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
     rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
-    data_forward:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-      body:
-        device_id: "{{ switch.id }}"
-        switch_mac: "{{ switch.mac }}"
-        dst_mac: "{{ receiver.mac }}"
-        output_port: 2
-      ok_status: 201
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201

--- a/playbooks/scenarios/gateway/data-inspection.yml
+++ b/playbooks/scenarios/gateway/data-inspection.yml
@@ -37,19 +37,10 @@
         dst_mac: "{{ receiver.mac }}"
         output_port: 2
       ok_status: 201
-    data_inspection_table_action:
-      control_name: TpsGwIngress
-      table_name: data_inspection_t
-      action:
-        name: "{{ 'data_inspect_packet_ipv4' if ip_version == '4' else 'data_inspect_packet_ipv6' }}"
-        match_fields:
-          - key: hdr.ethernet.src_mac
-            value: "{{ sender.mac }}"
-          - key: hdr.ethernet.etherType
-            value: "{{ '0x0800' if ip_version == '4' else '0x86dd' }}"
-        params:
-          - key: device
-            value: "{{ sender.id }}"
-          - key: switch_id
-            value: "{{ switch.id }}"
+    data_inspection:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
     sr1_rec_int_hops: 1

--- a/playbooks/scenarios/general/data_forward_basic.yml
+++ b/playbooks/scenarios/general/data_forward_basic.yml
@@ -13,7 +13,7 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Add table entry to data_forward_t table
+# Add table entries into data_forward_t tables
 - hosts: "{{ rec_host }}"
   gather_facts: no
   vars:
@@ -22,15 +22,15 @@
     - block:
       - name: Data forward structure
         debug:
-          var: data_forward
-
-      - name: Insert data forward table entry via endpoint {{ data_forward.url }}
+          var: data_forwards
+      - name: Insert data forward table
         uri:
-          url: "{{ data_forward.url }}"
+          url: "{{ item.url }}"
           method: POST
-          body_format: "{{ data_forward.body_format | default('json') }}"
-          body: "{{ data_forward.body }}"
-          status_code: "{{ data_forward.ok_status | default('200') }}"
+          body_format: "{{ item.body_format | default('json') }}"
+          body: "{{ item.body }}"
+          status_code: "{{ item.ok_status | default('200') }}"
+        with_items: "{{ data_forwards }}"
       when: execute_insert|bool
 
 ## Sending UDP packets expect all to be received
@@ -45,17 +45,22 @@
     inspection_data: "{{ sr_data_inspection_int | default(None) }}"
     max_received_packet_count: "{{ send_packet_count }}"
 
-# Delete table entry from data_forward_t table
+# Delete table entries from data_forward_t tables
 - hosts: "{{ rec_host }}"
   gather_facts: no
   vars:
     execute_insert: "{{ write_data_forward | default(False) }}"
   tasks:
-    - name: Delete data forward table entry via endpoint {{ data_forward.url }}
-      uri:
-        url: "{{ data_forward.url }}"
-        method: DELETE
-        body_format: "{{ data_forward.body_format | default('json') }}"
-        body: "{{ data_forward.body }}"
-        status_code: "{{ data_forward.ok_status | default('200') }}"
+    - block:
+      - name: Data forward structure
+        debug:
+          var: data_forwards
+      - name: Delete data forward table
+        uri:
+          url: "{{ item.url }}"
+          method: DELETE
+          body_format: "{{ item.body_format | default('json') }}"
+          body: "{{ item.body }}"
+          status_code: "{{ item.ok_status | default('200') }}"
+        with_items: "{{ data_forwards }}"
       when: execute_insert|bool

--- a/playbooks/scenarios/lab_trial/data-drop.yml
+++ b/playbooks/scenarios/lab_trial/data-drop.yml
@@ -15,7 +15,7 @@
 ---
 
 # Basic Data Drop scenario for the lab trial
-#
+
 # TO BE IMPLEMENTED WHEN DATA DROP HAS BEEN IMPLEMENTED ON THE AGGREGATE SWITCH
 #
 # If using data_drop_basic, move it to ../single_switch/data_drop_basic.yml ../general
@@ -25,32 +25,41 @@
 #    send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
 #    ip_version: "{{ scenario_send_ip_version | default(4) }}"
 #    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-#    switch: "{{ topo_dict.switches.gateway }}"
+#    switch: "{{ topo_dict.switches.aggregate }}"
+#    switch2: "{{ topo_dict.switches.core }}"
 #    remote_send_host: Camera1
 #    remote_rec_host: inet
-#    send_host: "{{ remote_send_host if run_mode == 'remote' else None }}"
-#    rec_host: "{{ remote_rec_host if run_mode == 'remote' else None }}"
+#    send_host: "{{ remote_send_host }}"
+#    rec_host: "{{ remote_rec_host }}"
 #    send_port: 4321
 #    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-#    sender_intf: "{{ '%s-eth0' % send_host if run_mode == 'remote' else '%s-eth1' % switch.name }}"
+#    sender_intf: "{{ '%s-eth0' % switch.name }}"
 #    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
 #    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-#    receiver_intf: "{{ '%s-eth0' % rec_host if run_mode == 'remote' else '%s-eth2' % switch.name }}"
+#    receiver_intf: "{{ '%s-eth0' % switch2.name }}"
 #    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
-#    data_drop_table_action:
-#      control_name: TpsAggIngress
-#      table_name: "{{ 'data_drop_udp_ipv%s_t' % ip_version if send_protocol == 'UDP' else 'data_drop_tcp_ipv%s_t' % ip_version }}"
-#      action:
-#        name: data_drop
-#        match_fields:
-#          - key: hdr.ethernet.src_mac
-#            value: "{{ sender.mac }}"
-#          - key: "{{ 'hdr.ipv%s.srcAddr' % ip_version }}"
-#            value: "{{ sender.ip  if ip_version == '4' else sender.ipv6 }}"
-#          - key: "{{ 'hdr.ipv%s.dstAddr' % ip_version }}"
-#            value: "{{ receiver.ip if ip_version == '4' else receiver.ipv6 }}"
-#          - key: "{{ 'hdr.udp.dst_port' if send_protocol == 'UDP' else 'hdr.tcp.dst_port' }}"
-#            value: "{{ send_port }}"
-#        params:
-#          - key: device
-#            value: "{{ sender.id }}"
+#    data_forwards:
+#      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+#        body:
+#          device_id: "{{ switch.id }}"
+#          switch_mac: "{{ switch.mac }}"
+#          dst_mac: "{{ receiver.mac }}"
+#          output_port: 1
+#        ok_status: 201
+#      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+#        body:
+#          device_id: "{{ switch2.id }}"
+#          switch_mac: "{{ switch2.mac }}"
+#          dst_mac: "{{ receiver.mac }}"
+#          output_port: 2
+#        ok_status: 201
+#    attack:
+#      url: "http://{{ sdn_ip }}:{{ sdn_port }}/gwAttack"
+#      body:
+#        src_ip: "{% if scenario_send_ip_version|int == 4 %}{{ sender.ip }}{% else %}{{ sender.ipv6 }}{% endif %}"
+#        packet_size: 112
+#        attack_type: "UDP Flood"
+#        dst_port: "{{ send_port }}"
+#        dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
+#        src_mac: "{{ sender.mac }}"
+#      ok_status: 201

--- a/playbooks/scenarios/lab_trial/data-drop.yml
+++ b/playbooks/scenarios/lab_trial/data-drop.yml
@@ -15,51 +15,46 @@
 ---
 
 # Basic Data Drop scenario for the lab trial
-
-# TO BE IMPLEMENTED WHEN DATA DROP HAS BEEN IMPLEMENTED ON THE AGGREGATE SWITCH
-#
-# If using data_drop_basic, move it to ../single_switch/data_drop_basic.yml ../general
-# and of course change the values. Below is simply a template to start with
-#- import_playbook: ../single_switch/data_drop_basic.yml
-#  vars:
-#    send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
-#    ip_version: "{{ scenario_send_ip_version | default(4) }}"
-#    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-#    switch: "{{ topo_dict.switches.aggregate }}"
-#    switch2: "{{ topo_dict.switches.core }}"
-#    remote_send_host: Camera1
-#    remote_rec_host: inet
-#    send_host: "{{ remote_send_host }}"
-#    rec_host: "{{ remote_rec_host }}"
-#    send_port: 4321
-#    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-#    sender_intf: "{{ '%s-eth0' % switch.name }}"
-#    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
-#    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-#    receiver_intf: "{{ '%s-eth0' % switch2.name }}"
-#    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
-#    data_forwards:
-#      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-#        body:
-#          device_id: "{{ switch.id }}"
-#          switch_mac: "{{ switch.mac }}"
-#          dst_mac: "{{ receiver.mac }}"
-#          output_port: 1
-#        ok_status: 201
-#      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-#        body:
-#          device_id: "{{ switch2.id }}"
-#          switch_mac: "{{ switch2.mac }}"
-#          dst_mac: "{{ receiver.mac }}"
-#          output_port: 2
-#        ok_status: 201
-#    attack:
-#      url: "http://{{ sdn_ip }}:{{ sdn_port }}/gwAttack"
-#      body:
-#        src_ip: "{% if scenario_send_ip_version|int == 4 %}{{ sender.ip }}{% else %}{{ sender.ipv6 }}{% endif %}"
-#        packet_size: 112
-#        attack_type: "UDP Flood"
-#        dst_port: "{{ send_port }}"
-#        dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
-#        src_mac: "{{ sender.mac }}"
-#      ok_status: 201
+- import_playbook: ../single_switch/data_drop_basic.yml
+  vars:
+    send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
+    ip_version: "{{ scenario_send_ip_version | default(4) }}"
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    switch: "{{ topo_dict.switches.aggregate }}"
+    switch2: "{{ topo_dict.switches.core }}"
+    remote_send_host: Camera1
+    remote_rec_host: inet
+    send_host: "{{ remote_send_host }}"
+    rec_host: "{{ remote_rec_host }}"
+    send_port: 4321
+    sender: "{{ topo_dict.hosts[remote_send_host] }}"
+    sender_intf: "{{ '%s-eth0' % switch.name }}"
+    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
+    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    receiver_intf: "{{ '%s-eth0' % switch2.name }}"
+    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 1
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch2.id }}"
+          switch_mac: "{{ switch2.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201
+    attack:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/gwAttack"
+      body:
+        src_ip: "{% if scenario_send_ip_version|int == 4 %}{{ sender.ip }}{% else %}{{ sender.ipv6 }}{% endif %}"
+        packet_size: 112
+        attack_type: "UDP Flood"
+        dst_port: "{{ send_port }}"
+        dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
+        src_mac: "{{ sender.mac }}"
+      ok_status: 201

--- a/playbooks/scenarios/lab_trial/data-forward.yml
+++ b/playbooks/scenarios/lab_trial/data-forward.yml
@@ -26,13 +26,14 @@
     rec_host: inet
     sender: "{{ topo_dict.hosts[send_host] }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
+    dst_mac: "{{ receiver.mac }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
         body:
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 1
+          output_port: 2
         ok_status: 201
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
         body:

--- a/playbooks/scenarios/lab_trial/data-forward.yml
+++ b/playbooks/scenarios/lab_trial/data-forward.yml
@@ -21,16 +21,23 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
+    switch2: "{{ topo_dict.switches.core }}"
     send_host: host1
     rec_host: inet
     sender: "{{ topo_dict.hosts[send_host] }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
-    dst_mac: "{{ receiver.mac }}"
-    data_forward:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-      body:
-        device_id: "{{ switch.id }}"
-        switch_mac: "{{ switch.mac }}"
-        dst_mac: "{{ receiver.mac }}"
-        output_port: 2
-      ok_status: 201
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 1
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch2.id }}"
+          switch_mac: "{{ switch2.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -29,6 +29,7 @@
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     dst_mac: "{{ receiver['mac'] }}"
+    controller_host: localhost
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
         body:
@@ -44,18 +45,17 @@
           dst_mac: "{{ receiver.mac }}"
           output_port: 2
         ok_status: 201
-    data_inspection_hop1:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
-      body:
-        device_id: "{{ switch.id }}"
-        device_mac: "{{ sender.mac }}"
-      ok_status: 201
-    data_inspection_hop2:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
-      body:
-        device_id: "{{ switch2.id }}"
-        device_mac: "{{ sender.mac }}"
-      ok_status: 201
+    data_inspections:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+        body:
+          device_id: "{{ switch.id }}"
+          device_mac: "{{ sender.mac }}"
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+        body:
+          device_id: "{{ switch2.id }}"
+          device_mac: "{{ sender.mac }}"
+        ok_status: 201
     sr1_rec_int_hops: 0
 
 # Basic Data Inspection scenario - receiving packets on core-eth3 (INT packets)
@@ -64,7 +64,7 @@
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    switch1: "{{ topo_dict.switches.aggregate }}"
+    switch: "{{ topo_dict.switches.aggregate }}"
     switch2: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: ae
@@ -73,16 +73,31 @@
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts.inet }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_inspection_hop1:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
-      body:
-        device_id: "{{ switch.id }}"
-        device_mac: "{{ sender.mac }}"
-      ok_status: 201
-    data_inspection_hop2:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
-      body:
-        device_id: "{{ switch2.id }}"
-        device_mac: "{{ sender.mac }}"
-      ok_status: 201
+    controller_host: localhost
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 1
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch2.id }}"
+          switch_mac: "{{ switch2.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201
+    data_inspections:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+        body:
+          device_id: "{{ switch.id }}"
+          device_mac: "{{ sender.mac }}"
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+        body:
+          device_id: "{{ switch2.id }}"
+          device_mac: "{{ sender.mac }}"
+        ok_status: 201
     sr1_rec_int_hops: 2

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -20,8 +20,8 @@
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    first_hop_switch: "{{ topo_dict.switches.aggregate }}"
-    second_hop_switch: "{{ topo_dict.switches.core }}"
+    switch: "{{ topo_dict.switches.aggregate }}"
+    switch2: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: inet
     send_host: "{{ remote_send_host }}"
@@ -29,32 +29,33 @@
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_inspection_table_action_hop1:
-      control_name: TpsAggIngress
-      table_name: data_inspection_t
-      action:
-        name: "{{ 'data_inspect_packet' }}"
-        match_fields:
-          - key: hdr.ethernet.src_mac
-            value: "{{ sender.mac }}"
-          - key: hdr.ethernet.etherType
-            value: "{{ '0x0800' if ip_version == '4' else '0x86dd' }}"
-        params:
-          - key: device
-            value: "{{ sender.id }}"
-          - key: switch_id
-            value: "{{ switch.id }}"
-    data_inspection_table_action_hop2:
-      control_name: TpsCoreIngress
-      table_name: data_inspection_t
-      action:
-        name: "{{ 'data_inspect_packet' }}"
-        match_fields:
-          - key: hdr.udp_int.dst_port
-            value: 555
-        params:
-          - key: switch_id
-            value: "{{ switch.id }}"
+    data_forwards:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 1
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch2.id }}"
+          switch_mac: "{{ switch2.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: 2
+        ok_status: 201
+    data_inspection_hop1:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
+    data_inspection_hop2:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch2.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
     sr1_rec_int_hops: 0
 
 # Basic Data Inspection scenario - receiving packets on core-eth3 (INT packets)
@@ -63,8 +64,8 @@
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    first_hop_switch: "{{ topo_dict.switches.aggregate }}"
-    second_hop_switch: "{{ topo_dict.switches.core }}"
+    switch1: "{{ topo_dict.switches.aggregate }}"
+    switch2: "{{ topo_dict.switches.core }}"
     remote_send_host: host1
     remote_rec_host: ae
     send_host: "{{ remote_send_host }}"
@@ -72,30 +73,16 @@
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts.inet }}"
     dst_mac: "{{ receiver['mac'] }}"
-    data_inspection_table_action_hop1:
-      control_name: TpsAggIngress
-      table_name: data_inspection_t
-      action:
-        name: "{{ 'data_inspect_packet' }}"
-        match_fields:
-          - key: hdr.ethernet.src_mac
-            value: "{{ sender.mac }}"
-          - key: hdr.ethernet.etherType
-            value: "{{ '0x0800' if ip_version == '4' else '0x86dd' }}"
-        params:
-          - key: device
-            value: "{{ sender.id }}"
-          - key: switch_id
-            value: "{{ switch.id }}"
-    data_inspection_table_action_hop2:
-      control_name: TpsCoreIngress
-      table_name: data_inspection_t
-      action:
-        name: "{{ 'data_inspect_packet' }}"
-        match_fields:
-          - key: hdr.udp_int.dst_port
-            value: 555
-        params:
-          - key: switch_id
-            value: "{{ switch.id }}"
+    data_inspection_hop1:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
+    data_inspection_hop2:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+      body:
+        device_id: "{{ switch2.id }}"
+        device_mac: "{{ sender.mac }}"
+      ok_status: 201
     sr1_rec_int_hops: 2

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -13,29 +13,22 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Add table entry to data_inspection_t table on aggregate switch
-- hosts: "{{ rec_host }}"
+# Enable switches for data inspection
+- hosts: "{{ controller_host }}"
   gather_facts: no
   tasks:
-    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop1.url }}
-      uri:
-        url: "{{ data_inspection_hop1.url }}"
-        method: POST
-        body_format: "{{ data_inspection_hop1.body_format | default('json') }}"
-        body: "{{ data_inspection_hop1.body }}"
-        status_code: "{{ data_inspection_hop1.ok_status | default('200') }}"
+    - name: show data inspection requests for enablement
+      debug:
+        var: data_inspections
 
-# Add table entry to data_inspection_t table on core switch
-- hosts: "{{ rec_host }}"
-  gather_facts: no
-  tasks:
-    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop2.url }}
+    - name: Data inspection requests
       uri:
-        url: "{{ data_inspection_hop2.url }}"
+        url: "{{ item.url }}"
         method: POST
-        body_format: "{{ data_inspection_hop2.body_format | default('json') }}"
-        body: "{{ data_inspection_hop2.body }}"
-        status_code: "{{ data_inspection_hop2.ok_status | default('200') }}"
+        body_format: "{{ item.body_format | default('json') }}"
+        body: "{{ item.body }}"
+        status_code: "{{ item.ok_status | default('200') }}"
+      with_items: "{{ data_inspections }}"
 
 # TODO/FIXME - Gateway TCP scenario receives 2x packets
 # Sending UDP packets expect all to be received with configured INT hops sr1_rec_int_hops
@@ -51,26 +44,20 @@
     max_received_packet_count: "{{ send_packet_count }}"
     discover_fwd_path: True
 
-# Delete table entry from data_inspection_t table on aggregate switch
-- hosts: "{{ rec_host }}"
+# Disable switches for data inspection
+- hosts: "{{ controller_host }}"
   gather_facts: no
   tasks:
-    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop1.url }}
-      uri:
-        url: "{{ data_inspection_hop1.url }}"
-        method: DELETE
-        body_format: "{{ data_inspection_hop1.body_format | default('json') }}"
-        body: "{{ data_inspection_hop1.body }}"
-        status_code: "{{ data_inspection_hop1.ok_status | default('200') }}"
+    - name: show data inspection requests for disablment
+      debug:
+        var: data_inspections
 
-# Delete table entry from data_inspection_t table on core switch
-- hosts: "{{ rec_host }}"
-  gather_facts: no
-  tasks:
-    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop2.url }}
+    - name: Data inspection requests
       uri:
-        url: "{{ data_inspection_hop2.url }}"
+        url: "{{ item.url }}"
         method: DELETE
-        body_format: "{{ data_inspection_hop2.body_format | default('json') }}"
-        body: "{{ data_inspection_hop2.body }}"
-        status_code: "{{ data_inspection_hop2.ok_status | default('200') }}"
+        body_format: "{{ item.body_format | default('json') }}"
+        body: "{{ item.body }}"
+        status_code: "{{ item.ok_status | default('200') }}"
+      with_items: "{{ data_inspections }}"
+

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -13,27 +13,29 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Add table entry "{{ data_inspection_table }}" on aggregate switch
-- import_playbook: ../test_cases/write_to_p4_table.yml
-  vars:
-    switch: "{{ first_hop_switch }}"
-    int_hops: "{{ sr1_rec_int_hops | default(0) }}"
-    te_conf_file: "~/di-inspect-create-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_classname: "{{ data_inspection_classname }}"
-    p4_table_action: "{{ data_inspection_table_action_hop1 }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "di-inspection-create-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
+# Add table entry to data_inspection_t table on aggregate switch
+- hosts: "{{ rec_host }}"
+  gather_facts: no
+  tasks:
+    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop1.url }}
+      uri:
+        url: "{{ data_inspection_hop1.url }}"
+        method: POST
+        body_format: "{{ data_inspection_hop1.body_format | default('json') }}"
+        body: "{{ data_inspection_hop1.body }}"
+        status_code: "{{ data_inspection_hop1.ok_status | default('200') }}"
 
-# Add table entry "{{ data_inspection_table }}" on core switch
-- import_playbook: ../test_cases/write_to_p4_table.yml
-  vars:
-    switch: "{{ second_hop_switch }}"
-    int_hops: "{{ sr1_rec_int_hops | default(0) }}"
-    te_conf_file: "~/di-inspect-create-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_classname: "{{ data_inspection_classname }}"
-    p4_table_action: "{{ data_inspection_table_action_hop2 }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "di-inspection-create-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
+# Add table entry to data_inspection_t table on core switch
+- hosts: "{{ rec_host }}"
+  gather_facts: no
+  tasks:
+    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop2.url }}
+      uri:
+        url: "{{ data_inspection_hop2.url }}"
+        method: POST
+        body_format: "{{ data_inspection_hop2.body_format | default('json') }}"
+        body: "{{ data_inspection_hop2.body }}"
+        status_code: "{{ data_inspection_hop2.ok_status | default('200') }}"
 
 # TODO/FIXME - Gateway TCP scenario receives 2x packets
 # Sending UDP packets expect all to be received with configured INT hops sr1_rec_int_hops
@@ -49,24 +51,26 @@
     max_received_packet_count: "{{ send_packet_count }}"
     discover_fwd_path: True
 
-# Delete table entry "{{ data_inspection_table }}" on aggregate
-- import_playbook: ../test_cases/write_to_p4_table.yml
-  vars:
-    switch: "{{ first_hop_switch }}"
-    int_hops: "{{ sr1_rec_int_hops | default(0) }}"
-    te_conf_file: "~/di-inspect-delete-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_inspection_table_action_hop1 }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "di-inspection-delete-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
-    p4_te_insert: False
+# Delete table entry from data_inspection_t table on aggregate switch
+- hosts: "{{ rec_host }}"
+  gather_facts: no
+  tasks:
+    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop1.url }}
+      uri:
+        url: "{{ data_inspection_hop1.url }}"
+        method: DELETE
+        body_format: "{{ data_inspection_hop1.body_format | default('json') }}"
+        body: "{{ data_inspection_hop1.body }}"
+        status_code: "{{ data_inspection_hop1.ok_status | default('200') }}"
 
-# Delete table entry "{{ data_inspection_table }}" on core
-- import_playbook: ../test_cases/write_to_p4_table.yml
-  vars:
-    switch: "{{ second_hop_switch }}"
-    int_hops: "{{ sr1_rec_int_hops | default(0) }}"
-    te_conf_file: "~/di-inspect-delete-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_inspection_table_action_hop2 }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "di-inspection-delete-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
-    p4_te_insert: False
+# Delete table entry from data_inspection_t table on core switch
+- hosts: "{{ rec_host }}"
+  gather_facts: no
+  tasks:
+    - name: Insert data inspection table entry via endpoint {{ data_inspection_hop2.url }}
+      uri:
+        url: "{{ data_inspection_hop2.url }}"
+        method: DELETE
+        body_format: "{{ data_inspection_hop2.body_format | default('json') }}"
+        body: "{{ data_inspection_hop2.body }}"
+        status_code: "{{ data_inspection_hop2.ok_status | default('200') }}"

--- a/playbooks/scenarios/single_switch/data_drop_basic.yml
+++ b/playbooks/scenarios/single_switch/data_drop_basic.yml
@@ -40,7 +40,7 @@
     inspection_data: "{{ sr1_data_inspection_int | default(None) }}"
     max_received_packet_count: "{{ send_packet_count }}"
 
-# Add table entry to {{ data_drop_table }}
+# Start packet mitigation
 - hosts: "{{ rec_host }}"
   gather_facts: no
   tasks:
@@ -65,7 +65,7 @@
     min_received_packet_count: 0
     max_received_packet_count: 0
 
-# Delete table entry from table {{ data_drop_table }}
+# Stop packet mitigation
 - hosts: "{{ rec_host }}"
   gather_facts: no
   tasks:

--- a/playbooks/scenarios/single_switch/data_inspection_basic.yml
+++ b/playbooks/scenarios/single_switch/data_inspection_basic.yml
@@ -28,15 +28,17 @@
         status_code: "{{ data_forward.ok_status | default('200') }}"
       when: execute_insert|bool
 
-# Add table entry to "{{ data_inspection_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
-  vars:
-    int_hops: "{{ sr1_rec_int_hops | default(0) }}"
-    te_conf_file: "~/di-inspect-create-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_classname: "{{ data_inspection_classname }}"
-    p4_table_action: "{{ data_inspection_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "di-inspection-create-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
+# Add table entry to data_inspection_t table
+- hosts: "{{ rec_host }}"
+  gather_facts: no
+  tasks:
+    - name: Insert data inspection table entry via endpoint {{ data_inspection.url }}
+      uri:
+        url: "{{ data_inspection.url }}"
+        method: POST
+        body_format: "{{ data_inspection.body_format | default('json') }}"
+        body: "{{ data_inspection.body }}"
+        status_code: "{{ data_inspection.ok_status | default('200') }}"
 
 # TODO/FIXME - Gateway TCP scenario receives 2x packets
 # Sending UDP packets expect all to be received with configured INT hops sr1_rec_int_hops
@@ -51,15 +53,17 @@
     inspection_data: "{{ sr1_data_inspection_int | default(None) }}"
     max_received_packet_count: "{{ send_packet_count }}"
 
-# Delete table entry to "{{ data_inspection_table }}"
-- import_playbook: ../test_cases/write_to_p4_table.yml
-  vars:
-    int_hops: "{{ sr1_rec_int_hops | default(0) }}"
-    te_conf_file: "~/di-inspect-delete-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.yml"
-    p4_table_action: "{{ data_inspection_table_action }}"
-    p4_te_log_dir: "{{ host_log_dir }}"
-    p4_te_log_file: "di-inspection-delete-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}.log"
-    p4_te_insert: False
+# Delete table entry from data_inspection_t table
+- hosts: "{{ rec_host }}"
+  gather_facts: no
+  tasks:
+    - name: Delete data inspection table entry via endpoint {{ data_inspection.url }}
+      uri:
+        url: "{{ data_inspection.url }}"
+        method: DELETE
+        body_format: "{{ data_inspection.body_format | default('json') }}"
+        body: "{{ data_inspection.body }}"
+        status_code: "{{ data_inspection.ok_status | default('200') }}"
 
 # TODO/FIXME - Gateway TCP scenario receives 2x packets
 # Sending packets expect all to be received with configured INT hops sr2_rec_int_hops

--- a/trans_sec/controller/ddos_sdn_controller.py
+++ b/trans_sec/controller/ddos_sdn_controller.py
@@ -95,6 +95,38 @@ class DdosSdnController:
         logger.warning('Could not find switch with device_id - [%s]',
                        df_req['device_id'])
 
+    def add_data_inspection(self, di_req):
+        """
+        Adds a data inspection table entry into the expected switch
+        """
+        self.__data_inspection(di_req)
+
+    def del_data_inspection(self, di_req):
+        """
+        Adds a data inspection table entry into the expected switch
+        """
+        self.__data_inspection(di_req, True)
+
+    def __data_inspection(self, di_req, del_flag=False):
+        """
+        Removes a device to mitigate an attack
+        """
+        logger.debug('di_req - [%s]', di_req)
+        for key, controller in self.controllers.items():
+            for switch in controller.switches:
+                logger.debug('switch - [%s]', switch.device_id)
+                if switch.device_id == di_req['device_id']:
+                    if del_flag:
+                        switch.del_data_inspection(
+                            di_req['device_id'], di_req['device_mac'])
+                    else:
+                        switch.add_data_inspection(
+                            di_req['device_id'], di_req['device_mac'])
+                    return
+
+        logger.warning('Could not find switch with device_id - [%s]',
+                       di_req['device_id'])
+
     def remove_attacker(self, attack):
         """
         Removes a device to mitigate an attack

--- a/trans_sec/controller/http_server_flask.py
+++ b/trans_sec/controller/http_server_flask.py
@@ -39,6 +39,9 @@ class SDNControllerServer:
             DataForward, '/dataForward',
             resource_class_kwargs={'sdn_controller': self.sdn_controller})
         self.api.add_resource(
+            DataInspection, '/dataInspection',
+            resource_class_kwargs={'sdn_controller': self.sdn_controller})
+        self.api.add_resource(
             GwAttack, '/gwAttack',
             resource_class_kwargs={'sdn_controller': self.sdn_controller})
         self.api.add_resource(
@@ -85,6 +88,34 @@ class DataForward(Resource):
 
         logger.info('Attack args - [%s]', args)
         self.sdn_controller.del_data_forward(args)
+        return json.dumps({"success": True}), 201
+
+
+class DataInspection(Resource):
+    """
+    Class for exposing web service to enter a data_forward entry into the P4
+    gateway.p4
+    """
+    def __init__(self, **kwargs):
+        self.sdn_controller = kwargs['sdn_controller']
+        self.parser = reqparse.RequestParser()
+        self.parser.add_argument('device_id', type=int, default=0)
+        self.parser.add_argument('device_mac', type=str)
+
+    def post(self):
+        logger.info('Attack requested')
+        args = self.parser.parse_args()
+
+        logger.info('Attack args - [%s]', args)
+        self.sdn_controller.add_data_inspection(args)
+        return json.dumps({"success": True}), 201
+
+    def delete(self):
+        logger.info('Attacker to remove')
+        args = self.parser.parse_args()
+
+        logger.info('Attack args - [%s]', args)
+        self.sdn_controller.del_data_inspection(args)
         return json.dumps({"success": True}), 201
 
 

--- a/trans_sec/p4runtime_lib/aggregate_switch.py
+++ b/trans_sec/p4runtime_lib/aggregate_switch.py
@@ -31,8 +31,7 @@ import ipaddress
 import logging
 
 from trans_sec.p4runtime_lib.p4rt_switch import P4RuntimeSwitch
-from trans_sec.consts import IPV4_TYPE, IPV6_TYPE, UDP_INT_DST_PORT
-from trans_sec.controller.ddos_sdn_controller import AGG_CTRL_KEY
+from trans_sec.consts import UDP_INT_DST_PORT
 
 logger = logging.getLogger('aggregate_switch')
 
@@ -48,46 +47,6 @@ class AggregateSwitch(P4RuntimeSwitch):
     def write_multicast_entry(self, hosts):
         super(self.__class__, self).write_multicast_entry(hosts)
         self.write_arp_flood()
-
-    def add_data_inspection(self, dev_id, dev_mac):
-        logger.info(
-            'Adding data inspection to aggregate device [%s] with device ID '
-            '- [%s] and mac - [%s]', self.device_id, dev_id, dev_mac)
-        # Northbound Traffic Inspection for IPv4
-        action_params = {
-            'device': dev_id,
-            'switch_id': self.sw_info['id']
-        }
-        table_entry = self.p4info_helper.build_table_entry(
-            table_name='{}.data_inspection_t'.format(self.p4_ingress),
-            match_fields={
-                'hdr.ethernet.src_mac': dev_mac,
-                'hdr.ethernet.etherType': IPV4_TYPE
-            },
-            action_name='{}.data_inspect_packet'.format(
-                self.p4_ingress),
-            action_params=action_params)
-        self.write_table_entry(table_entry)
-
-        # Northbound Traffic Inspection for IPv6
-        action_params = {
-            'device': dev_id,
-            'switch_id': self.sw_info['id']
-        }
-        table_entry = self.p4info_helper.build_table_entry(
-            table_name='{}.data_inspection_t'.format(self.p4_ingress),
-            match_fields={
-                'hdr.ethernet.src_mac': dev_mac,
-                'hdr.ethernet.etherType': IPV6_TYPE
-            },
-            action_name='{}.data_inspect_packet'.format(
-                self.p4_ingress),
-            action_params=action_params)
-        self.write_table_entry(table_entry)
-        logger.info(
-            'Installed Northbound Packet Inspection for device - [%s]'
-            ' with MAC - [%s] with action params - [%s]',
-            AGG_CTRL_KEY, dev_mac, action_params)
 
     @staticmethod
     def __parse_attack(**kwargs):

--- a/trans_sec/p4runtime_lib/core_switch.py
+++ b/trans_sec/p4runtime_lib/core_switch.py
@@ -87,8 +87,32 @@ class CoreSwitch(P4RuntimeSwitch):
                 'hdr.udp_int.dst_port': UDP_INT_DST_PORT
             },
             action_name=action_name,
-            action_params=action_params)
+            action_params=action_params
+        )
         self.write_table_entry(table_entry)
+
+    def del_data_inspection(self, dev_id, dev_mac):
+        logger.info(
+            'Adding data inspection entry to core device [%s] with device ID '
+            '- [%s]', self.device_id, dev_id)
+
+        action_params = {
+            'switch_id': dev_id
+        }
+        table_name = '{}.data_inspection_t'.format(self.p4_ingress)
+        action_name = '{}.data_inspect_packet'.format(self.p4_ingress)
+        logger.info(
+            'Insert params into table - [%s] for action [%s] '
+            'with params [%s]',
+            table_name, action_name, action_params)
+        table_entry = self.p4info_helper.build_table_entry(
+            table_name=table_name,
+            match_fields={
+                'hdr.udp_int.dst_port': UDP_INT_DST_PORT
+            },
+            action_name=action_name,
+        )
+        self.delete_table_entry(table_entry)
 
     def setup_telemetry_rpt(self, ae_ip):
         logger.info(

--- a/trans_sec/p4runtime_lib/gateway_switch.py
+++ b/trans_sec/p4runtime_lib/gateway_switch.py
@@ -32,7 +32,6 @@ import logging
 from abc import ABC
 
 from trans_sec.p4runtime_lib.p4rt_switch import P4RuntimeSwitch
-from trans_sec.consts import IPV4_TYPE, IPV6_TYPE
 from trans_sec.utils.convert import decode_num, decode_ipv4
 
 logger = logging.getLogger('gateway_switch')
@@ -79,47 +78,6 @@ class GatewaySwitch(P4RuntimeSwitch, ABC):
                 logger.error(
                     'Unexpected error reading NAT digest from [%s] - [%s]',
                     self.name, e)
-
-    def add_data_inspection(self, dev_id, dev_mac):
-        logger.info(
-            'Adding data inspection to gateway device [%s] with device ID '
-            '- [%s] and mac - [%s]', self.device_id, dev_id, dev_mac)
-        # Northbound Traffic Inspection for IPv4
-        action_params = {
-            'device': dev_id,
-            'switch_id': self.sw_info['id']
-        }
-        table_entry = self.p4info_helper.build_table_entry(
-            table_name='{}.data_inspection_t'.format(self.p4_ingress),
-            match_fields={
-                'hdr.ethernet.src_mac': dev_mac,
-                'hdr.ethernet.etherType': IPV4_TYPE
-            },
-            action_name='{}.data_inspect_packet_ipv4'.format(
-                self.p4_ingress),
-            action_params=action_params)
-        self.write_table_entry(table_entry)
-
-        # Northbound Traffic Inspection for IPv6
-        action_params = {
-            'device': dev_id,
-            'switch_id': self.sw_info['id']
-        }
-        table_entry = self.p4info_helper.build_table_entry(
-            table_name='{}.data_inspection_t'.format(self.p4_ingress),
-            match_fields={
-                'hdr.ethernet.src_mac': dev_mac,
-                'hdr.ethernet.etherType': IPV6_TYPE
-            },
-            action_name='{}.data_inspect_packet_ipv6'.format(
-                self.p4_ingress),
-            action_params=action_params)
-        self.write_table_entry(table_entry)
-
-        logger.info(
-            'Installed Northbound Packet Inspection for device with'
-            ' MAC - [%s] with action params - [%s]',
-            dev_mac, action_params)
 
     @staticmethod
     def __parse_attack(**kwargs):

--- a/trans_sec/p4runtime_lib/p4rt_switch.py
+++ b/trans_sec/p4runtime_lib/p4rt_switch.py
@@ -171,7 +171,46 @@ class P4RuntimeSwitch(SwitchConnection, ABC):
             return False
 
     def add_data_inspection(self, dev_id, dev_mac):
-        raise NotImplemented
+        logger.info(
+            'Adding data inspection to device [%s] with ID '
+            '- [%s] and mac - [%s]', self.device_id, dev_id, dev_mac)
+        action_params = {
+            'device': dev_id,
+            'switch_id': self.sw_info['id']
+        }
+        table_entry = self.p4info_helper.build_table_entry(
+            table_name='{}.data_inspection_t'.format(self.p4_ingress),
+            match_fields={
+                'hdr.ethernet.src_mac': dev_mac,
+            },
+            action_name='{}.data_inspect_packet'.format(
+                self.p4_ingress),
+            action_params=action_params
+        )
+        self.write_table_entry(table_entry)
+
+        logger.info(
+            'Installed Northbound Packet Inspection for device with'
+            ' MAC - [%s] with action params - [%s]',
+            dev_mac, action_params)
+
+    def del_data_inspection(self, dev_id, dev_mac):
+        logger.info(
+            'Removing data inspection to device [%s] with ID '
+            '- [%s] and mac - [%s]', self.device_id, dev_id, dev_mac)
+        table_entry = self.p4info_helper.build_table_entry(
+            table_name='{}.data_inspection_t'.format(self.p4_ingress),
+            match_fields={
+                'hdr.ethernet.src_mac': dev_mac,
+            },
+            action_name='{}.data_inspect_packet'.format(
+                self.p4_ingress),
+        )
+        self.delete_table_entry(table_entry)
+
+        logger.info(
+            'Installed Northbound Packet Inspection for device with'
+            ' MAC - [%s]', dev_mac)
 
     def add_switch_id(self, dev_id):
         pass


### PR DESCRIPTION
#### What does this PR do?
Fixes #224 
Add new web service call to insert and delete data_inspection records on the switches
Updates the integration tests to now use the web service rather than the write_to_p4_table.yml playbook
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
ensure CI jobs complete successfully.
#### Any background context you want to provide?
No more instances of write_to_p4_table being used in CI. All have been replaced with web service calls
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? see #229
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? just updated them to use the new API
