### PR TITLE
Updates to environment build scripts to reflect lessons learned from Barefoot academy

### DIFF
--- a/automation/p4/mininet/variables.tf
+++ b/automation/p4/mininet/variables.tf
@@ -17,7 +17,7 @@ variable "secret_key" {}
 variable "build_id" {}
 variable "ec2_region" {}
 # Image generated from env-build script for build_env='mininet'
-variable "mininet_ami" {default ="ami-01d5d0aec6e487afe"}
+variable "mininet_ami" {default ="ami-0572f054b71fc1cdd"}
 # Image hand created
 variable "hcp_ami" {default ="ami-0c5f7b13179115b5a"}
 

--- a/automation/p4/mininet/variables.tf
+++ b/automation/p4/mininet/variables.tf
@@ -17,7 +17,7 @@ variable "secret_key" {}
 variable "build_id" {}
 variable "ec2_region" {}
 # Image generated from env-build script for build_env='mininet'
-variable "mininet_ami" {default ="ami-0572f054b71fc1cdd"}
+variable "mininet_ami" {default ="ami-01d5d0aec6e487afe"}
 # Image hand created
 variable "hcp_ami" {default ="ami-0c5f7b13179115b5a"}
 

--- a/automation/p4/tofino/aws-security.tf
+++ b/automation/p4/tofino/aws-security.tf
@@ -55,6 +55,13 @@ resource "aws_security_group" "tps" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    from_port = 3000
+    to_port = 3000
+    protocol = "tcp"
+  }
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
     from_port = var.tofino_model_start_port
     to_port = var.tofino_model_end_port
     protocol = "tcp"

--- a/automation/p4/tofino/variables.tf
+++ b/automation/p4/tofino/variables.tf
@@ -28,8 +28,8 @@ variable "availability_zone" {default = "us-west-2a"}
 variable "tofino" {
   default = {
     sde_version = "9.2.0"
-    p4rt_ami = "ami-0eb9501a7d485f7f8"
-    bfrt_ami = "ami-01ff01cf2d4abb838"
+    p4rt_ami = "ami-043e6714f3d0863f2"
+    bfrt_ami = "ami-01a5ff54de23b6739"
   }
 }
 

--- a/playbooks/general/final_env_setup.yml
+++ b/playbooks/general/final_env_setup.yml
@@ -18,11 +18,12 @@
   gather_facts: no
 
   tasks:
-    - name: Install python-pip
+    - name: Install python3-pip and wireshark
       become: yes
       apt:
         name:
           - python3-pip
+          - wireshark-qt
 
     - name: Install ansible
       become: yes

--- a/playbooks/tofino/bf-sde/bf-sde-build.yml
+++ b/playbooks/tofino/bf-sde/bf-sde-build.yml
@@ -15,14 +15,20 @@
   import_playbook: bf-sde-setup.yml
   vars:
     install_dir: "{{ bf_sde_install_dir | default(ansible_facts['user_dir']) }}"
+    sde_dir: "{{ install_dir }}/bf-sde-{{ bf_sde_version }}"
+    sde_build_dir: "{{ sde_dir }}/build"
+    sde_install_dir: "{{ sde_dir }}/install"
 
 - hosts: all
   vars:
     install_dir: "{{ bf_sde_install_dir | default(ansible_facts['user_dir']) }}"
     profile: "{{ bf_sde_profile | default('p4_runtime_profile') }}"
+    sde_dir: "{{ install_dir }}/bf-sde-{{ bf_sde_version }}"
+    sde_install_dir: "{{ sde_dir }}/install"
+    diags_build_dir: "{{ sde_dir }}/build/bf-diags"
   environment:
-    SDE: "{{ install_dir }}/bf-sde-{{ bf_sde_version }}"
-    SDE_INSTALL: "{{ install_dir }}/bf-sde-{{ bf_sde_version }}/install"
+    SDE: "{{ sde_dir }}"
+    SDE_INSTALL: "{{ sde_install_dir }}"
   tasks:
     - name: Install bf-sde with {{ profile }} profile
       command: >
@@ -31,12 +37,52 @@
       async: 10800
       poll: 15
 
+    - name: Patch 9.2.0 bug
+      block:
+        - name: Copy patch file
+          copy:
+            src: templates/bf-sde-9.2.0.patch
+            dest: "{{ sde_install_dir }}/bf-sde-9.2.0.patch"
+
+        - name: Apply patch
+          shell: "patch -p1 < {{ sde_install_dir }}/bf-sde-9.2.0.patch"
+          args:
+            chdir: "{{ sde_dir }}/pkgsrc/bf-drivers"
+
+        - name: Make patch
+          shell: "make -j4"
+          args:
+            chdir: "{{ sde_install_dir }}/../build/bf-drivers"
+
+        - name: Install patch
+          command: "make install"
+          args:
+            chdir: "{{ sde_install_dir }}/../build/bf-drivers"
+      when: bf_sde_version == "9.2.0"
+
     - name: Copy build python libs to Python {{ python_version }} runtime
       become: yes
       shell: >
         sudo cp -r
         $SDE_INSTALL/lib/python3.4/*
         /usr/local/lib/python{{ python_version }}/dist-packages/
+
+    - name: Create directory $SDE_INSTALL/lib/python3.4/p4testutils
+      file:
+        path: "{{ sde_install_dir }}/lib/python3.4/site-packages/p4testutils"
+        state: directory
+
+    - name: Create and copy built 2.7 p4testutils to buld libs in $SDE_INSTALL Python 3.4
+      shell: >
+        cp -r
+        $SDE_INSTALL/lib/python2.7/site-packages/p4testutils/*
+        $SDE_INSTALL/lib/python3.4/site-packages/p4testutils/
+
+    - name: Copy built 3.4 python libs to SDE Python {{ python_version }}
+      shell: >
+        cp -r
+        $SDE_INSTALL/lib/python3.4
+        $SDE_INSTALL/lib/python{{ python_version }}
 
     - name: Copy built python tofino libs to Python {{ python_version }} runtime
       shell: >
@@ -80,3 +126,9 @@
     - name: Set python version {{ python_version }} as the default runtime
       become: yes
       command: "sudo update-alternatives --install /usr/bin/python python /usr/bin/python{{ python_version }} 0"
+
+    - name: Install thrift into the Python default runtime
+      become: yes
+      pip:
+        name:
+          - thrift

--- a/playbooks/tofino/bf-sde/templates/bf-sde-9.2.0.patch
+++ b/playbooks/tofino/bf-sde/templates/bf-sde-9.2.0.patch
@@ -1,0 +1,58 @@
+diff --git a/src/bf_rt/bf_rt_pre/bf_rt_pre_table_key_impl.cpp b/src/bf_rt/bf_rt_pre/bf_rt_pre_table_key_impl.cpp
+index 5b5343de39..79d02c536e 100644
+--- a/src/bf_rt/bf_rt_pre/bf_rt_pre_table_key_impl.cpp
++++ b/src/bf_rt/bf_rt_pre/bf_rt_pre_table_key_impl.cpp
+@@ -111,7 +111,7 @@ bf_status_t BfRtPREMGIDTableKey::setValue(const bf_rt_id_t &field_id,
+   // Check if the key field value is valid based on size of the key field
+   // We don't have common utils function for key bounds check, so
+   // use anonymous namesapce function for PRE.
+-  size_t size = (key_field->getSize() + 7) / 8;
++  size_t size = key_field->getSize();
+   status = keyValueBoundsCheck(value, size);
+   if (status != BF_SUCCESS) {
+     LOG_ERROR("%s:%d %s : Value %" PRIu64
+@@ -213,7 +213,7 @@ bf_status_t BfRtPREMulticastNodeTableKey::setValue(const bf_rt_id_t &field_id,
+   // Check if the key field value is valid based on size of the key field
+   // We don't have common utils function for key bounds check, so
+   // use anonymous namesapce function for PRE.
+-  size_t size = (key_field->getSize() + 7) / 8;
++  size_t size = key_field->getSize();
+   status = keyValueBoundsCheck(value, size);
+   if (status != BF_SUCCESS) {
+     LOG_ERROR("%s:%d %s : Value %" PRIu64
+@@ -317,7 +317,7 @@ bf_status_t BfRtPREECMPTableKey::setValue(const bf_rt_id_t &field_id,
+   // Check if the key field value is valid based on size of the key field
+   // We don't have common utils function for key bounds check, so
+   // use anonymous namesapce function for PRE.
+-  size_t size = (key_field->getSize() + 7) / 8;
++  size_t size = key_field->getSize();
+   status = keyValueBoundsCheck(value, size);
+   if (status != BF_SUCCESS) {
+     LOG_ERROR("%s:%d %s : Value %" PRIu64
+@@ -420,7 +420,7 @@ bf_status_t BfRtPRELAGTableKey::setValue(const bf_rt_id_t &field_id,
+   // Check if the key field value is valid based on size of the key field
+   // We don't have common utils function for key bounds check, so
+   // use anonymous namesapce function for PRE.
+-  size_t size = (key_field->getSize() + 7) / 8;
++  size_t size = key_field->getSize();
+   status = keyValueBoundsCheck(value, size);
+   if (status != BF_SUCCESS) {
+     LOG_ERROR("%s:%d %s : Value %" PRIu64
+@@ -522,7 +522,7 @@ bf_status_t BfRtPREMulticastPruneTableKey::setValue(const bf_rt_id_t &field_id,
+   // Check if the key field value is valid based on size of the key field
+   // We don't have common utils function for key bounds check, so
+   // use anonymous namesapce function for PRE.
+-  size_t size = (key_field->getSize() + 7) / 8;
++  size_t size = key_field->getSize();
+   status = keyValueBoundsCheck(value, size);
+   if (status != BF_SUCCESS) {
+     LOG_ERROR("%s:%d %s : Value %" PRIu64
+@@ -626,7 +626,7 @@ bf_status_t BfRtPREMulticastPortTableKey::setValue(const bf_rt_id_t &field_id,
+   // Check if the key field value is valid based on size of the key field
+   // We don't have common utils function for key bounds check, so
+   // use anonymous namesapce function for PRE.
+-  size_t size = (key_field->getSize() + 7) / 8;
++  size_t size = key_field->getSize();
+   status = keyValueBoundsCheck(value, size);
+   if (status != BF_SUCCESS) {
+     LOG_ERROR("%s:%d %s : Value %" PRIu64


### PR DESCRIPTION
#### What does this PR do?
Fixes #256 
Adds wireshark to all P4 image builds
Opens port 3000 for tofino integration automation tests
Applies Barefoot bug patch to 9.2.0
Update Tofino Python 3.6 environment primarily for the Barefoot p4testutils and now installing thrift

#### Do you have any concerns with this PR?
Adding that patch file to this repository is of concern. @RandyLevensalor, Please let me know if you think this is not kosher and I can either remove it or upload the patch to S3...
#### How can the reviewer verify this PR? ensure CI has not broken as new AMIs have been added that were built via these scripts.
#### Any background context you want to provide?
These are primarily things that are required for being able to run the labs from Barefoot Academy
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
