### PR TITLE
Add new optional int_switch_id switch attribute

### DIFF
--- a/bin/start_ae.py
+++ b/bin/start_ae.py
@@ -45,6 +45,17 @@ def get_args():
     parser.add_argument('-t', '--type', dest='type', required=True,
                         choices=['OINC', 'SIMPLE', 'LOGGING', 'INT'],
                         help='Acceptable values OINC|SIMPLE|LOGGING|INT')
+    parser.add_argument('-c', '--sdn-attack-ctx', dest='sdn_ctx',
+                        required=False, default='gwAttack',
+                        help='the URL to the SDN controller')
+    parser.add_argument('-pc', '--packet-count', required=False, type=int,
+                        default=100,
+                        help='Number of packets to hit alert within the '
+                             'sample-interval')
+    parser.add_argument('-si', '--sample-interval', required=False, type=int,
+                        default=60,
+                        help='Number of seconds the packet count needs to hit '
+                             'to trigger alert')
     return parser.parse_args()
 
 
@@ -72,10 +83,12 @@ def main():
     logger.info('Retrieving http session from url - [%s]', args.sdn_url)
     http_session = HttpSession(args.sdn_url)
 
-    logger.info('Type of AE to instantiate - [%s]', args.type)
     if args.type == 'SIMPLE':
         logger.info('SimpleAE instantiated')
-        ae = SimpleAE(http_session)
+        logger.debug('SDN Context - [%s]', args.sdn_ctx)
+        ae = SimpleAE(http_session, packet_count=args.packet_count,
+                      sample_interval=args.sample_interval,
+                      sdn_attack_context=args.sdn_ctx)
     elif args.type == 'OINC':
         logger.info('Oinc instantiated')
         ae = Oinc(http_session)

--- a/playbooks/general/setup_source.yml
+++ b/playbooks/general/setup_source.yml
@@ -39,6 +39,8 @@
           - python3-pip
           - python3-devel
           - gcc-c++
+          - tcpdump
+          - net-tools
       register: apt_rc
       retries: 3
       delay: 10

--- a/playbooks/general/templates/ae_service.sh.j2
+++ b/playbooks/general/templates/ae_service.sh.j2
@@ -14,4 +14,11 @@
 # limitations under the License.
 #
 # Runs the Analytics Engine
-{{ trans_sec_dir }}/bin/start_ae.py -f {{ log_dir }}/{{ service_name }}.log -s {{ sdn_url }} -l {{ log_level }} -i {{ monitor_intf }} -t {{ srvc_type }}
+{{ trans_sec_dir }}/bin/start_ae.py -f {{ log_dir }}/{{ service_name }}.log \
+-s {{ sdn_url }} \
+-l {{ log_level }} \
+-i {{ monitor_intf }} \
+-t {{ srvc_type }} \
+-pc {{ packet_count | default(100) }} \
+-si {{ sample_interval | default(60) }} \
+-c {{ sdn_attack_context | default('gwAttack') }}

--- a/playbooks/scenarios/full/packet-flood.yml
+++ b/playbooks/scenarios/full/packet-flood.yml
@@ -31,8 +31,8 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     switch_egress_intf: eth4
     dst_mac: "{{ sender['switch_mac'] }}"
-    receiver_log_filename: "udp-flood-receiver-{{ rec_host }}-{{ send_protocol }}-1.out"
-    sender_log_filename: "udp-flood-sender-{{ send_host }}-{{ send_protocol }}-1.out"
+    receiver_log_filename: "{{ send_protocol }}-flood-receiver-{{ rec_host }}-{{ send_protocol }}-1.out"
+    sender_log_filename: "{{ send_protocol }}-flood-sender-{{ send_host }}-{{ send_protocol }}-1.out"
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 1) }}"
     send_src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 2) }}"
     send_packet_count: 150
@@ -45,7 +45,7 @@
       body:
         src_ip: "{% if scenario_send_ip_version|int == 4 %}{{ sender.ip }}{% else %}{{ sender.ipv6 }}{% endif %}"
         packet_size: 112
-        attack_type: "UDP Flood"
+        attack_type: "{{ send_protocol }} Flood"
         dst_port: "{{ send_port }}"
         dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
         src_mac: "{{ sender.mac }}"
@@ -69,8 +69,8 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     switch_egress_intf: eth3
     dst_mac: "{{ sender['switch_mac'] }}"
-    receiver_log_filename: "udp-flood-receiver-{{ rec_host }}-{{ send_protocol }}-2.out"
-    sender_log_filename: "udp-flood-sender-{{ send_host }}-{{ send_protocol }}-2.out"
+    receiver_log_filename: "{{ send_protocol }}-flood-receiver-{{ rec_host }}-{{ send_protocol }}-2.out"
+    sender_log_filename: "{{ send_protocol }}-flood-sender-{{ send_host }}-{{ send_protocol }}-2.out"
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 3) }}"
     send_src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 4) }}"
     send_packet_count: 150
@@ -83,7 +83,7 @@
       body:
         src_ip: "{% if scenario_send_ip_version|int == 4 %}{{ sender.ip }}{% else %}{{ sender.ipv6 }}{% endif %}"
         packet_size: 112
-        attack_type: "UDP Flood"
+        attack_type: "{{ send_protocol }} Flood"
         dst_port: "{{ send_port }}"
         dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
         src_mac: "{{ sender.mac }}"
@@ -107,8 +107,8 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     switch_egress_intf: eth3
     dst_mac: "{{ sender['switch_mac'] }}"
-    receiver_log_filename: "udp-flood-receiver-{{ rec_host }}-{{ send_protocol }}-3.out"
-    sender_log_filename: "udp-flood-sender-{{ send_host }}-{{ send_protocol }}-3.out"
+    receiver_log_filename: "{{ send_protocol }}-flood-receiver-{{ rec_host }}-{{ send_protocol }}-3.out"
+    sender_log_filename: "{{ send_protocol }}-flood-sender-{{ send_host }}-{{ send_protocol }}-3.out"
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 5) }}"
     send_src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 6) }}"
     send_packet_count: 150
@@ -121,7 +121,7 @@
       body:
         src_ip: "{% if scenario_send_ip_version|int == 4 %}{{ sender.ip }}{% else %}{{ sender.ipv6 }}{% endif %}"
         packet_size: 112
-        attack_type: "UDP Flood"
+        attack_type: "{{ send_protocol }} Flood"
         dst_port: "{{ send_port }}"
         dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
         src_mac: "{{ sender.mac }}"

--- a/playbooks/scenarios/lab_trial/all.yml
+++ b/playbooks/scenarios/lab_trial/all.yml
@@ -85,3 +85,51 @@
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 6
+
+# Data Inspection scenarios for UDP and IPv4
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 4
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_max_rec_packet_count: 175
+    di_send_loops: 2
+    di_send_loop_delay: 5
+
+# Data Inspection scenarios for UDP and IPv6 with AE for testing dropping packets
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 6
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_max_rec_packet_count: 175
+    di_send_loops: 2
+    di_send_loop_delay: 5
+
+# Data Inspection scenarios for TCP and IPv4 with AE for testing dropping packets
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 4
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_max_rec_packet_count: 175
+    di_send_loops: 2
+    di_send_loop_delay: 5
+
+# Data Inspection scenarios for TCP and IPv6 with AE for testing dropping packets
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 6
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_max_rec_packet_count: 175
+    di_send_loops: 2
+    di_send_loop_delay: 5

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -13,6 +13,16 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
+# Restart AE service to ensure moving window gets reset
+- hosts: ae
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Restart tps-tofino-ae
+      systemd:
+        name: tps-tofino-ae
+        state: restarted
+
 # Add table entries into data_forward_t tables
 - hosts: "{{ rec_host }}"
   gather_facts: no
@@ -54,15 +64,28 @@
 - import_playbook: ../test_cases/send_receive.yml
   vars:
     int_hops: "{{ sr1_rec_int_hops | default(0) }}"
-    receiver_log_filename: "di_basic_receiver-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}-1.out"
-    sender_log_filename: "di_basic_sender-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}-1.out"
+    receiver_log_filename: "{{ di_log_prfx | default('di') }}_basic_receiver-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}-1.out"
+    sender_log_filename: "{{ di_log_prfx | default('di') }}_basic_sender-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}-1.out"
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 9) }}"
     send_src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 10) }}"
-    send_packet_count: "{{ '%s' % 100 | random(seed=now|int + 11) }}"
+    send_packet_count: "{{ di_send_packet_count | default('%s' % 100 | random(seed=now|int + 11)) }}"
     inspection_data: "{{ sr1_data_inspection_int | default(None) }}"
-    min_received_packet_count: "{{ send_packet_count|int - 10 }}" # TODO/FIXME - Have been noticing missing packets on TNA
-    max_received_packet_count: "{{ send_packet_count }}"
+    # TODO/FIXME - Have been noticing missing packets on TNA so we should not do the '- 10' (see issue #268)
+    min_received_packet_count: "{{ di_min_rec_packet_count | default(send_packet_count|int - 10) }}"
+    max_received_packet_count: "{{ di_max_rec_packet_count | default(send_packet_count) }}"
+    send_loops: "{{ di_send_loops | default(1) }}"
+    send_loop_delay: "{{ di_send_loop_delay | default(5) }}"
     discover_fwd_path: True
+    cleanup_rest_call:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"
+      body:
+        src_ip: "{% if scenario_send_ip_version|int == 4 %}{{ sender.ip }}{% else %}{{ sender.ipv6 }}{% endif %}"
+        packet_size: 112
+        attack_type: "{{ send_protocol }} Flood"
+        dst_port: "{{ send_port }}"
+        dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
+        src_mac: "{{ sender.mac }}"
+      ok_status: 201
 
 # Disable switches for data inspection
 - hosts: "{{ rec_host }}"

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -201,11 +201,16 @@
         msg: "{{ max_packet_count }} < {{ packet_count }} or {{ min_packet_count }} > {{ packet_count }}"
       when: min_packet_count|int > packet_count|int or max_packet_count|int < packet_count|int
 
-    - name: Call web service
-      uri:
-        url: "{{ cleanup_rest_call.url }}"
-        method: DELETE
-        body_format: json
-        body: "{{ cleanup_rest_call.body }}"
-        status_code: "{{ cleanup_rest_call.ok_status }}"
+    - block:
+        - name: Show the web service attributes
+          debug:
+            var: cleanup_rest_call
+
+        - name: Call web service
+          uri:
+            url: "{{ cleanup_rest_call.url }}"
+            method: DELETE
+            body_format: json
+            body: "{{ cleanup_rest_call.body }}"
+            status_code: "{{ cleanup_rest_call.ok_status }}"
       when: cleanup_rest_call is defined

--- a/playbooks/tofino/setup_nodes-lab_trial.yml
+++ b/playbooks/tofino/setup_nodes-lab_trial.yml
@@ -65,3 +65,6 @@
     srvc_type: SIMPLE
     sdn_url: "http://{{ sdn_ip }}:{{ sdn_port }}"
     monitor_intf: "{{ ae_monitor_intf }}"
+    packet_count: 100
+    sample_interval: 60
+    sdn_attack_context: aggAttack

--- a/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
@@ -82,7 +82,7 @@ switches:
   aggregate:
     name: aggregate
     id: 0
-    int_id: 1234
+    int_id: 123
     runtime_p4info: {{ remote_scripts_dir }}/p4/aggregate.tofino/p4info.pb.txt
     tofino_bin: {{ remote_scripts_dir }}/p4/aggregate.tofino/pipe/tofino.bin
     ctx_json: {{ remote_scripts_dir }}/p4/aggregate.tofino/pipe/context.json
@@ -108,6 +108,7 @@ switches:
   core:
     name: core
     id: 0
+    int_id: 234
     runtime_p4info: {{ remote_scripts_dir }}/p4/core.tofino/p4info.pb.txt
     tofino_bin: {{ remote_scripts_dir }}/p4/core.tofino/pipe/tofino.bin
     ctx_json: {{ remote_scripts_dir }}/p4/core.tofino/pipe/context.json

--- a/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
@@ -82,6 +82,7 @@ switches:
   aggregate:
     name: aggregate
     id: 0
+    int_id: 1234
     runtime_p4info: {{ remote_scripts_dir }}/p4/aggregate.tofino/p4info.pb.txt
     tofino_bin: {{ remote_scripts_dir }}/p4/aggregate.tofino/pipe/tofino.bin
     ctx_json: {{ remote_scripts_dir }}/p4/aggregate.tofino/pipe/context.json

--- a/trans_sec/analytics/oinc.py
+++ b/trans_sec/analytics/oinc.py
@@ -35,7 +35,8 @@ class PacketAnalytics(object):
     """
     Analytics Engine class
     """
-    def __init__(self, sdn_interface, packet_count=100, sample_interval=60):
+    def __init__(self, sdn_interface, packet_count=100, sample_interval=60,
+                 sdn_attack_context='gwAttack'):
         """
         Constructor
         :param sdn_interface: the HTTP interface to the SDN Controller
@@ -48,8 +49,10 @@ class PacketAnalytics(object):
         self.sample_interval = sample_interval
         self.count_map = dict()
         self.sniff_stop = threading.Event()
+        self.sdn_attack_context = sdn_attack_context
 
-        logger.debug("Completed binding packet layers")
+        logger.debug("Started AE with attack call to [%s/%s]",
+                     self.sdn_interface, self.sdn_attack_context)
 
     def start_sniffing(self, iface, udp_dport=UDP_TRPT_DST_PORT):
         """
@@ -84,7 +87,7 @@ class PacketAnalytics(object):
         :raises Exception: due to the remote HTTP POST
         """
         logger.info('Start attack - %s', attack_dict)
-        self.sdn_interface.post('gwAttack', attack_dict)
+        self.sdn_interface.post(self.sdn_attack_context, attack_dict)
 
     @abc.abstractmethod
     def process_packet(self, packet, udp_dport=UDP_INT_DST_PORT):
@@ -299,9 +302,10 @@ class SimpleAE(PacketAnalytics):
     Simple implementation of PacketAnalytics where the count for detecting
     attack notifications is based on the unique hash of the extracted INT data
     """
-    def __init__(self, sdn_interface, packet_count=100, sample_interval=60):
-        super(self.__class__, self).__init__(sdn_interface, packet_count,
-                                             sample_interval)
+    def __init__(self, sdn_interface, packet_count=100, sample_interval=60,
+                 sdn_attack_context='gwAttack'):
+        super(self.__class__, self).__init__(
+            sdn_interface, packet_count, sample_interval, sdn_attack_context)
         # Holds the last time an attack call was issued to the SDN controller
         self.attack_map = dict()
 

--- a/trans_sec/bfruntime_lib/aggregate_switch.py
+++ b/trans_sec/bfruntime_lib/aggregate_switch.py
@@ -98,7 +98,7 @@ class AggregateSwitch(BFRuntimeSwitch):
                                     DataTuple(data_inspection_action_val_1,
                                               int(dev_id)),
                                     DataTuple(data_inspection_action_val_2,
-                                              int(self.device_id))
+                                              int(self.int_device_id))
                                 ])
 
     def del_data_inspection(self, dev_id, dev_mac):
@@ -152,9 +152,10 @@ class AggregateSwitch(BFRuntimeSwitch):
                                              int(kwargs['dst_port']))
                                 ])
 
-    def add_switch_id(self, dev_id):
+    def add_switch_id(self):
         logger.info(
-            'Inserting device ID [%s] into add_switch_id_t table', dev_id)
+            'Inserting device ID [%s] into add_switch_id_t table',
+            self.int_device_id)
 
         try:
             self.insert_table_entry(add_switch_id_tbl,
@@ -162,7 +163,7 @@ class AggregateSwitch(BFRuntimeSwitch):
                                     [KeyTuple(add_switch_id_tbl_key,
                                               value=UDP_INT_DST_PORT)],
                                     [DataTuple(add_switch_id_action_val,
-                                               val=dev_id)])
+                                               val=self.int_device_id)])
         except Exception as e:
             if 'ALREADY_EXISTS' in str(e):
                 pass

--- a/trans_sec/bfruntime_lib/core_switch.py
+++ b/trans_sec/bfruntime_lib/core_switch.py
@@ -106,7 +106,7 @@ class CoreSwitch(BFRuntimeSwitch):
                                 [KeyTuple(data_inspection_tbl_key,
                                           value=UDP_INT_DST_PORT)],
                                 [DataTuple(data_inspection_action_val,
-                                           val=int(dev_id))])
+                                           val=int(self.int_device_id))])
 
     def del_data_inspection(self, dev_id, dev_mac):
         self.delete_table_entry(data_inspection_tbl,

--- a/trans_sec/controller/abstract_controller.py
+++ b/trans_sec/controller/abstract_controller.py
@@ -50,7 +50,7 @@ class AbstractController(object):
         for switch in self.switches:
             logger.info('Starting digest listeners on device [%s]',
                         switch.grpc_addr)
-            switch.add_switch_id(switch.device_id)
+            switch.add_switch_id()
             switch.start_digest_listeners()
 
     def stop(self):
@@ -109,8 +109,9 @@ class AbstractController(object):
             if device is not None and add_di:
                 logger.info('Adding inspection to mac [%s] on device [%s]',
                             device['mac'], sw.grpc_addr)
-                sw.add_data_inspection(dev_id=device['id'],
-                                       dev_mac=device['mac'])
+                sw.add_data_inspection(
+                    dev_id=device.get('int_id', device['id']),
+                    dev_mac=device['mac'])
         else:
             logger.info('No south links to install')
 

--- a/trans_sec/p4runtime_lib/aggregate_switch.py
+++ b/trans_sec/p4runtime_lib/aggregate_switch.py
@@ -55,7 +55,7 @@ class AggregateSwitch(P4RuntimeSwitch):
         # Northbound Traffic Inspection for IPv4
         action_params = {
             'device': dev_id,
-            'switch_id': self.device_id
+            'switch_id': self.int_device_id
         }
         table_entry = self.p4info_helper.build_table_entry(
             table_name='{}.data_inspection_t'.format(self.p4_ingress),
@@ -80,7 +80,7 @@ class AggregateSwitch(P4RuntimeSwitch):
         # Northbound Traffic Inspection for IPv4
         action_params = {
             'device': dev_id,
-            'switch_id': self.device_id
+            'switch_id': self.int_device_id
         }
         table_entry = self.p4info_helper.build_table_entry(
             table_name='{}.data_inspection_t'.format(self.p4_ingress),
@@ -133,9 +133,9 @@ class AggregateSwitch(P4RuntimeSwitch):
         logger.info('%s Dropping TCP Packets from %s',
                     self.name, kwargs.get('src_ip'))
 
-    def add_switch_id(self, dev_id):
+    def add_switch_id(self):
         action_params = {
-            'switch_id': self.device_id
+            'switch_id': self.int_device_id
         }
         table_entry = self.p4info_helper.build_table_entry(
             table_name='{}.add_switch_id_t'.format(self.p4_ingress),

--- a/trans_sec/p4runtime_lib/core_switch.py
+++ b/trans_sec/p4runtime_lib/core_switch.py
@@ -74,10 +74,10 @@ class CoreSwitch(P4RuntimeSwitch):
     def add_data_inspection(self, dev_id, dev_mac):
         logger.info(
             'Adding data inspection entry to core device [%s] with device ID '
-            '- [%s]', self.device_id, dev_id)
+            '- [%s]', self.int_device_id, dev_id)
 
         action_params = {
-            'switch_id': dev_id
+            'switch_id': self.int_device_id
         }
         table_name = '{}.data_inspection_t'.format(self.p4_ingress)
         action_name = '{}.data_inspect_packet'.format(self.p4_ingress)

--- a/trans_sec/p4runtime_lib/p4rt_switch.py
+++ b/trans_sec/p4runtime_lib/p4rt_switch.py
@@ -191,9 +191,10 @@ class P4RuntimeSwitch(SwitchConnection, ABC):
     def add_data_inspection(self, dev_id, dev_mac):
         logger.info(
             'Adding data inspection to device [%s] with ID '
-            '- [%s] and mac - [%s]', self.device_id, dev_id, dev_mac)
+            '- [%s] and mac - [%s]',
+            self.device_id, self.int_device_id, dev_mac)
         action_params = {
-            'device': dev_id,
+            'device': self.int_device_id,
             'switch_id': self.sw_info['id']
         }
         table_entry = self.p4info_helper.build_table_entry(
@@ -230,7 +231,7 @@ class P4RuntimeSwitch(SwitchConnection, ABC):
             'Installed Northbound Packet Inspection for device with'
             ' MAC - [%s]', dev_mac)
 
-    def add_switch_id(self, dev_id):
+    def add_switch_id(self):
         pass
 
     def build_device_config(self):

--- a/trans_sec/switch.py
+++ b/trans_sec/switch.py
@@ -36,6 +36,7 @@ class SwitchConnection(object):
         self.mac = sw_info['mac']
         self.type = sw_info['type']
         self.device_id = sw_info['id']
+        self.int_device_id = sw_info.get('int_id', sw_info['id'])
         self.grpc_addr = sw_info['grpc']
         self.digest_thread = Thread(target=self.receive_digests)
 
@@ -144,7 +145,7 @@ class SwitchConnection(object):
         logger.info('Switch does not support attack mitigation')
         pass
 
-    def add_switch_id(self, dev_id):
+    def add_switch_id(self):
         pass
 
     @abstractmethod


### PR DESCRIPTION
#### What does this PR do?
Fixes #271 
Adds new optional int_switch_id member to the switch object and topology that will default to the "id" field when it doesn't exist.
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
Check the centos@ae:/var/log/transparent-security files generated by receive_packets after running the lab_trial/TNA tofino automation tests to ensure non of the switch_id values being read from these packets do not have any with the value '0'
#### Any background context you want to provide?
When running P4 on Tofino, the device ID of each program on each switch VM is always 0 and really should only be used for obtaining the GRPC socket connection. For backwards compatibility, we will be defaulting to the old 'id' value when 'int_id'
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? I do not believe so
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no, but we really should add validation for these values.
