### PR TITLE
Tna packet lenghts

### DIFF
--- a/automation/p4/tofino/scenarios.tf
+++ b/automation/p4/tofino/scenarios.tf
@@ -16,6 +16,7 @@ locals {
 }
 
 resource "null_resource" "transparent-security-run-scenario-tests" {
+  count = var.test_case == "none" ? 0 : 1
   depends_on = [null_resource.tps-tofino-setup-nodes]
 
   provisioner "remote-exec" {

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -472,9 +472,9 @@ control TpsAggEgressDeparser(
     in metadata meta,
     in egress_intrinsic_metadata_for_deparser_t eg_intr_dprsr_md) {
 
-    Checksum() checksum;
+    Checksum() ipv4_checksum;
     apply {
-        hdr.ipv4.hdrChecksum = checksum.update(
+        hdr.ipv4.hdrChecksum = ipv4_checksum.update(
                 {hdr.ipv4.version,
                  hdr.ipv4.ihl,
                  hdr.ipv4.diffserv,
@@ -486,16 +486,6 @@ control TpsAggEgressDeparser(
                  hdr.ipv4.protocol,
                  hdr.ipv4.srcAddr,
                  hdr.ipv4.dstAddr});
-
-        hdr.udp.cksum = checksum.update(
-                {hdr.udp.src_port,
-                 hdr.udp.dst_port,
-                 hdr.udp.len});
-
-        hdr.udp_int.cksum = checksum.update(
-                {hdr.udp_int.src_port,
-                 hdr.udp_int.dst_port,
-                 hdr.udp_int.len});
 
         packet.emit(hdr.ethernet);
         packet.emit(hdr.arp);

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -208,14 +208,16 @@ control TpsAggIngress(
         hdr.int_shim.next_proto = hdr.ipv4.protocol;
         hdr.ipv4.protocol = TYPE_UDP;
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.ipv4.totalLen = hdr.ipv4.totalLen + ((INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
+        hdr.ipv4.totalLen = hdr.ipv4.totalLen + (
+            (INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
     }
 
     action data_inspect_packet_ipv6() {
         hdr.int_shim.next_proto = hdr.ipv6.next_hdr_proto;
         hdr.ipv6.next_hdr_proto = TYPE_UDP;
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.ipv6.payload_len = hdr.ipv6.payload_len + ((INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
+        hdr.ipv6.payload_len = hdr.ipv6.payload_len + (
+            (INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
     }
 
     table data_inspection_t {
@@ -239,7 +241,8 @@ control TpsAggIngress(
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
 
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.udp_int.len = hdr.udp.len + ((INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
+        hdr.udp_int.len = hdr.udp.len + (
+            (INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
     }
 
     action insert_udp_int_for_tcp_ipv4() {
@@ -257,6 +260,8 @@ control TpsAggIngress(
     }
 
      apply {
+        /* Value will be set with the udp_int.dst_port in the parser
+           which would be incorrect in this case */
         if (hdr.tcp.isValid()) {
             meta.dst_port = hdr.tcp.dst_port;
         }
@@ -264,11 +269,8 @@ control TpsAggIngress(
             // Add switch ID into existing INT data
             add_switch_id_t.apply();
         } else {
-            // Check to see if need to add INT
-            data_inspection_t.apply();
-
             // Add IP & Protocol specific data to new INT data
-            if (hdr.int_shim.isValid()) {
+            if (data_inspection_t.apply().hit) {
                 if (hdr.udp_int.isValid()) {
                     insert_udp_int_for_udp();
                 }
@@ -288,8 +290,9 @@ control TpsAggIngress(
         }
 
         // Basic forwarding and drop logic
-        data_forward_t.apply();
-        data_drop_t.apply();
+        if (data_drop_t.apply().miss) {
+            data_forward_t.apply();
+        }
     }
 }
 
@@ -337,68 +340,9 @@ parser TpsAggEgressParser(
     }
     state parse_ethernet {
         packet.extract(hdr.ethernet);
-        transition select(hdr.ethernet.etherType) {
-            TYPE_ARP: parse_arp;
-            TYPE_IPV4: parse_ipv4;
-            TYPE_IPV6: parse_ipv6;
-            default: accept;
-        }
-    }
-
-    state parse_ipv4 {
-        packet.extract(hdr.ipv4);
-        transition select(hdr.ipv4.protocol) {
-            TYPE_UDP: parse_udp_int;
-            TYPE_TCP: parse_tcp;
-            default: accept;
-        }
-    }
-
-    state parse_ipv6 {
-        packet.extract(hdr.ipv6);
-        transition select(hdr.ipv6.next_hdr_proto) {
-            TYPE_UDP: parse_udp_int;
-            TYPE_TCP: parse_tcp;
-            default: accept;
-        }
-    }
-
-    state parse_udp_int {
-        packet.extract(hdr.udp_int);
-        transition select(hdr.udp_int.dst_port) {
-            UDP_INT_DST_PORT: parse_int_shim;
-            default: accept;
-        }
-    }
-
-    state parse_int_shim {
-        packet.extract(hdr.int_shim);
-        transition parse_int_hdr;
-    }
-
-    state parse_int_hdr {
-        packet.extract(hdr.int_header);
-        transition select(hdr.int_shim.next_proto){
-            TYPE_UDP: parse_udp;
-            TYPE_TCP: parse_tcp;
-            default: accept;
-        }
-    }
-
-    state parse_tcp {
-        packet.extract(hdr.tcp);
         transition accept;
     }
 
-    state parse_udp {
-        packet.extract(hdr.udp);
-        transition accept;
-    }
-
-    state parse_arp {
-        packet.extract(hdr.arp);
-        transition accept;
-    }
 }
 
 control TpsAggEgress(
@@ -423,32 +367,8 @@ control TpsAggEgressDeparser(
     in metadata meta,
     in egress_intrinsic_metadata_for_deparser_t eg_intr_dprsr_md) {
 
-    Checksum() ipv4_checksum;
     apply {
-        hdr.ipv4.hdrChecksum = ipv4_checksum.update(
-                {hdr.ipv4.version,
-                 hdr.ipv4.ihl,
-                 hdr.ipv4.diffserv,
-                 hdr.ipv4.totalLen,
-                 hdr.ipv4.identification,
-                 hdr.ipv4.flags,
-                 hdr.ipv4.fragOffset,
-                 hdr.ipv4.ttl,
-                 hdr.ipv4.protocol,
-                 hdr.ipv4.srcAddr,
-                 hdr.ipv4.dstAddr});
-
-        packet.emit(hdr.ethernet);
-        packet.emit(hdr.arp);
-        packet.emit(hdr.ipv4);
-        packet.emit(hdr.ipv6);
-        packet.emit(hdr.udp_int);
-        packet.emit(hdr.int_shim);
-        packet.emit(hdr.int_header);
-        packet.emit(hdr.int_meta_2);
-        packet.emit(hdr.int_meta);
-        packet.emit(hdr.udp);
-        packet.emit(hdr.tcp);
+        packet.emit(hdr);
     }
 }
 

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -214,10 +214,6 @@ control TpsAggIngress(
 
         hdr.int_meta.switch_id = switch_id;
         hdr.int_meta.orig_mac = hdr.ethernet.src_mac;
-
-        #ifdef IMPL_COUNTER
-        forwardedPackets.count(device);
-        #endif
     }
 
     action data_inspect_packet_ipv4() {
@@ -225,14 +221,14 @@ control TpsAggIngress(
         hdr.int_shim.next_proto = hdr.ipv4.protocol;
         hdr.ipv4.protocol = TYPE_UDP;
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.ipv4.totalLen = hdr.ipv4.totalLen + IPV4_INT_UDP_BYTES;
+        hdr.ipv4.totalLen = hdr.ipv4.totalLen + (IPV4_HDR_BYTES + INT_SHIM_BASE_SIZE + UDP_HDR_BYTES);
     }
 
     action data_inspect_packet_ipv6() {
         hdr.int_shim.next_proto = hdr.ipv6.next_hdr_proto;
         hdr.ipv6.next_hdr_proto = TYPE_UDP;
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.ipv6.payload_len = hdr.ipv6.payload_len + IPV6_INT_UDP_BYTES;
+        hdr.ipv6.payload_len = hdr.ipv6.payload_len + (IPV6_HDR_BYTES + INT_SHIM_BASE_SIZE + UDP_HDR_BYTES);
     }
 
     table data_inspection_t {

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -253,7 +253,7 @@ control TpsAggIngress(
         hdr.udp_int.setValid();
         hdr.udp_int.src_port = UDP_INT_SRC_PORT;
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
-        hdr.udp_int.len = hdr.ipv6.payload_len - IPV6_HDR_BYTES;
+        hdr.udp_int.len = hdr.ipv6.payload_len;
     }
 
      apply {
@@ -269,19 +269,18 @@ control TpsAggIngress(
 
             // Add IP & Protocol specific data to new INT data
             if (hdr.int_shim.isValid()) {
+                if (hdr.udp_int.isValid()) {
+                    insert_udp_int_for_udp();
+                }
                 if (hdr.ipv4.isValid()) {
                     data_inspect_packet_ipv4();
-                    if (hdr.udp_int.isValid()) {
-                        insert_udp_int_for_udp();
-                    } else if (hdr.tcp.isValid()) {
+                    if (hdr.tcp.isValid()) {
                         insert_udp_int_for_tcp_ipv4();
                     }
                 }
                 else if (hdr.ipv6.isValid()) {
                     data_inspect_packet_ipv6();
-                    if (hdr.udp_int.isValid()) {
-                        insert_udp_int_for_udp();
-                    } else if (hdr.tcp.isValid()) {
+                    if (hdr.tcp.isValid()) {
                         insert_udp_int_for_tcp_ipv6();
                     }
                 }

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -221,14 +221,14 @@ control TpsAggIngress(
         hdr.int_shim.next_proto = hdr.ipv4.protocol;
         hdr.ipv4.protocol = TYPE_UDP;
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.ipv4.totalLen = hdr.ipv4.totalLen + (IPV4_HDR_BYTES + INT_SHIM_BASE_SIZE + UDP_HDR_BYTES);
+        hdr.ipv4.totalLen = hdr.ipv4.totalLen + ((INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
     }
 
     action data_inspect_packet_ipv6() {
         hdr.int_shim.next_proto = hdr.ipv6.next_hdr_proto;
         hdr.ipv6.next_hdr_proto = TYPE_UDP;
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.ipv6.payload_len = hdr.ipv6.payload_len + (IPV6_HDR_BYTES + INT_SHIM_BASE_SIZE + UDP_HDR_BYTES);
+        hdr.ipv6.payload_len = hdr.ipv6.payload_len + ((INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
     }
 
     table data_inspection_t {
@@ -252,7 +252,7 @@ control TpsAggIngress(
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
 
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
-        hdr.udp_int.len = hdr.udp.len + INT_SHIM_UDP_BYTES;
+        hdr.udp_int.len = hdr.udp.len + ((INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + UDP_HDR_BYTES);
     }
 
     action insert_udp_int_for_tcp_ipv4() {

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -472,9 +472,9 @@ control TpsAggEgressDeparser(
     in metadata meta,
     in egress_intrinsic_metadata_for_deparser_t eg_intr_dprsr_md) {
 
-    Checksum() ipv4_checksum;
+    Checksum() checksum;
     apply {
-        hdr.ipv4.hdrChecksum = ipv4_checksum.update(
+        hdr.ipv4.hdrChecksum = checksum.update(
                 {hdr.ipv4.version,
                  hdr.ipv4.ihl,
                  hdr.ipv4.diffserv,
@@ -486,6 +486,16 @@ control TpsAggEgressDeparser(
                  hdr.ipv4.protocol,
                  hdr.ipv4.srcAddr,
                  hdr.ipv4.dstAddr});
+
+        hdr.udp.cksum = checksum.update(
+                {hdr.udp.src_port,
+                 hdr.udp.dst_port,
+                 hdr.udp.len});
+
+        hdr.udp_int.cksum = checksum.update(
+                {hdr.udp_int.src_port,
+                 hdr.udp_int.dst_port,
+                 hdr.udp_int.len});
 
         packet.emit(hdr.ethernet);
         packet.emit(hdr.arp);

--- a/p4/core/core_tna.p4
+++ b/p4/core/core_tna.p4
@@ -302,7 +302,7 @@ control TpsCoreEgress(
         hdr.trpt_hdr.in_type = TRPT_HDR_IN_TYPE_IPV4;
         hdr.trpt_ipv6.payload_len = hdr.ipv4.totalLen + (IPV6_HDR_BYTES + UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES + ETH_HDR_BYTES);
         hdr.trpt_ipv4.totalLen = hdr.ipv4.totalLen + (IPV4_HDR_BYTES + UDP_HDR_BYTES + (INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + SWITCH_ID_HDR_BYTES + 6);
-        hdr.trpt_udp.len = hdr.ipv4.totalLen + (IPV4_HDR_BYTES + (INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + SWITCH_ID_HDR_BYTES + 6);
+        hdr.trpt_udp.len = hdr.ipv4.totalLen + (IPV4_HDR_BYTES + (INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + SWITCH_ID_HDR_BYTES - 6);
     }
 
     /* Sets the trpt_eth.in_type for IPv6 */
@@ -328,8 +328,6 @@ control TpsCoreEgress(
         hdr.trpt_ipv4.protocol = TYPE_UDP;
         hdr.trpt_ipv4.srcAddr = hdr.ipv4.srcAddr;
         hdr.trpt_ipv4.dstAddr = ae_ip;
-
-        hdr.trpt_udp.len = eg_intr_md.pkt_length + (UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES);
     }
 
     /**
@@ -343,7 +341,6 @@ control TpsCoreEgress(
         hdr.trpt_ipv6.next_hdr_proto = TYPE_UDP;
         hdr.trpt_ipv6.srcAddr = hdr.ipv6.srcAddr;
         hdr.trpt_ipv6.dstAddr = ae_ip;
-        hdr.trpt_udp.len = eg_intr_md.pkt_length + (UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES);
     }
 
     /**

--- a/p4/include/tps_consts.p4
+++ b/p4/include/tps_consts.p4
@@ -34,16 +34,12 @@
 /* The number of bytes in an int_meta_2 switch_id */
 #define SWITCH_ID_HDR_BYTES 4
 
-/* The INT Shim length at the gateway */
+/* The INT Shim length at creation in bytes */
 #define INT_SHIM_BASE_SIZE 7
 /* Amount to add to the INT Shim length at each hop */
 #define INT_SHIM_HOP_SIZE 1
 /* Number of bytes per INT Shim length */
 #define BYTES_PER_SHIM 4
-/* The INT Shim bytes when created at aggregate on TNA derived by INT_SHIM_BASE_SIZE * BYTES_PER_SHIM */
-#define INT_SHIM_BYTES 28
-/* Derived by INT_SHIM_BYTES + UDP_HDR_BYTES */
-#define INT_SHIM_UDP_BYTES 36
 
 /* Number of bytes used by a UDP header */
 #define UDP_HDR_BYTES 8

--- a/p4/include/tps_consts.p4
+++ b/p4/include/tps_consts.p4
@@ -36,12 +36,6 @@
 
 /* The INT Shim length at the gateway */
 #define INT_SHIM_BASE_SIZE 7
-/* Value derived from IPV4_HDR_BYTES + INT_SHIM_BASE_SIZE + UDP_HDR_BYTES  */
-#define IPV4_INT_UDP_BYTES 35
-/* Telemetry report additional IPv4 bytes from IPV4_HDR_BYTES + UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES */
-#define TRPT_IPV4_BYTES 46
-/* Value derived from IPV6_HDR_BYTES + INT_SHIM_BASE_SIZE + UDP_HDR_BYTES  */
-#define IPV6_INT_UDP_BYTES 72
 /* Amount to add to the INT Shim length at each hop */
 #define INT_SHIM_HOP_SIZE 1
 /* Number of bytes per INT Shim length */

--- a/playbooks/scenarios/lab_trial/all.yml
+++ b/playbooks/scenarios/lab_trial/all.yml
@@ -94,7 +94,7 @@
     scenario_send_ip_version: 4
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 175
+    di_max_rec_packet_count: 250
     di_send_loops: 2
     di_send_loop_delay: 5
 
@@ -106,7 +106,7 @@
     scenario_send_ip_version: 6
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 175
+    di_max_rec_packet_count: 250
     di_send_loops: 2
     di_send_loop_delay: 5
 
@@ -118,7 +118,7 @@
     scenario_send_ip_version: 4
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 175
+    di_max_rec_packet_count: 250
     di_send_loops: 2
     di_send_loop_delay: 5
 
@@ -130,6 +130,6 @@
     scenario_send_ip_version: 6
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 175
+    di_max_rec_packet_count: 250
     di_send_loops: 2
     di_send_loop_delay: 5

--- a/playbooks/scenarios/lab_trial/all.yml
+++ b/playbooks/scenarios/lab_trial/all.yml
@@ -94,9 +94,8 @@
     scenario_send_ip_version: 4
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 250
     di_send_loops: 2
-    di_send_loop_delay: 5
+    di_send_loop_delay: 10
 
 # Data Inspection scenarios for UDP and IPv6 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -106,9 +105,8 @@
     scenario_send_ip_version: 6
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 250
     di_send_loops: 2
-    di_send_loop_delay: 5
+    di_send_loop_delay: 10
 
 # Data Inspection scenarios for TCP and IPv4 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -118,9 +116,8 @@
     scenario_send_ip_version: 4
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 250
     di_send_loops: 2
-    di_send_loop_delay: 5
+    di_send_loop_delay: 10
 
 # Data Inspection scenarios for TCP and IPv6 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -130,6 +127,5 @@
     scenario_send_ip_version: 6
     di_send_packet_count: 150
     di_min_rec_packet_count: 99
-    di_max_rec_packet_count: 250
     di_send_loops: 2
-    di_send_loop_delay: 5
+    di_send_loop_delay: 10


### PR DESCRIPTION
#### What does this PR do?
Fixes #263 Fixes #253 
This patch fixes the packet length fields from both aggregate_tna.p4 & core_tna.p4.
Also implemented some best P4 coding practices and optimizations learned during the first 9 courses with Barefoot Academy with the TNA model.
#### Do you have any concerns with this PR?
None of our tests validate any of the length fields and probably should
Checksums are still broken see #287 
#### How can the reviewer verify this PR?
Ensure CI passes. Also check the egress packets at each stage with Wireshark and our int.lua plugin
#### Any background context you want to provide?
Most of the length fields were incorrect and may have been that way in mininet although mininet and v1model allowed for more complex mathematical operations making it a bit more difficult to calculate on TNA.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
