### PR TITLE
Agg return path

### DIFF
--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -34,11 +34,14 @@ parser TpsAggParser(
 
     state start {
         tofino_parser.apply(packet, ig_intr_md);
+        meta.ingress_port = ig_intr_md.ingress_port;
         transition parse_ethernet;
     }
 
     state parse_ethernet {
         packet.extract(hdr.ethernet);
+        meta.src_mac = hdr.ethernet.src_mac;
+
         transition select(hdr.ethernet.etherType) {
             TYPE_ARP: parse_arp;
             TYPE_IPV4: parse_ipv4;
@@ -123,6 +126,48 @@ control TpsAggIngress(
 
     DirectCounter<bit<32>>(CounterType_t.PACKETS) droppedPackets;
 
+    bool src_miss;
+    PortId_t src_move;
+
+    action smac_hit(PortId_t port) {
+        src_move = port ^ ig_intr_md.ingress_port;
+    }
+
+    action smac_miss() {
+        src_miss = true;
+    }
+
+    table smac {
+        key = { hdr.ethernet.src_mac : exact; }
+        actions = {
+            smac_hit;
+            smac_miss;
+        }
+
+        const default_action = smac_miss;
+        size = 1024;
+    }
+
+    action data_forward(PortId_t port) {
+        ig_tm_md.ucast_egress_port = port;
+    }
+
+    action data_forward_miss() {
+        data_forward(1);
+    }
+
+    table data_forward_t {
+        key = {
+            hdr.ethernet.dst_mac: exact;
+        }
+        actions = {
+            data_forward;
+            data_forward_miss;
+        }
+        size = TABLE_SIZE;
+        default_action = data_forward_miss();
+    }
+
     action data_drop() {
         ig_dprsr_md.drop_ctl = 0x1;
         droppedPackets.count();
@@ -140,21 +185,6 @@ control TpsAggIngress(
         }
         counters = droppedPackets;
         size = TABLE_SIZE;
-    }
-
-    action data_forward(PortId_t port) {
-        ig_tm_md.ucast_egress_port = port;
-    }
-
-    table data_forward_t {
-        key = {
-            hdr.ethernet.dst_mac: exact;
-        }
-        actions = {
-            data_forward;
-        }
-        size = TABLE_SIZE;
-        default_action = data_forward(1);
     }
 
     action add_switch_id(bit<32> switch_id) {
@@ -264,6 +294,7 @@ control TpsAggIngress(
         if (hdr.tcp.isValid()) {
             meta.dst_port = hdr.tcp.dst_port;
         }
+
         if (hdr.int_shim.isValid()) {
             // Add switch ID into existing INT data
             add_switch_id_t.apply();
@@ -291,8 +322,20 @@ control TpsAggIngress(
         // Basic forwarding and drop logic
         if (data_drop_t.apply().miss) {
             data_forward_t.apply();
-            if(ig_intr_md.ingress_port == ig_tm_md.ucast_egress_port) {
+            if (ig_intr_md.ingress_port == ig_tm_md.ucast_egress_port) {
+                // Drop the packet
                 ig_dprsr_md.drop_ctl = 0x1;
+            } else {
+                if (ig_intr_md.ingress_port > 1) {
+                    smac.apply();
+                    /* Send a digest if MAC address is unknown or if it is known
+                     * but attached to a different port as long as it does not come
+                     * in port 1, which should only be a switch. Nodes should be
+                     * plugged into the others. */
+                    if ((src_miss == true || src_move != 0)) {
+                        ig_dprsr_md.digest_type = 1;
+                    }
+                }
             }
         }
     }
@@ -308,7 +351,17 @@ control TpsAggDeparser(
     in metadata meta,
     in ingress_intrinsic_metadata_for_deparser_t ig_dprsr_md) {
 
+    Digest<digest_t>() smac_digest;
+
     apply {
+        // Generate a digest, if digest_type is set in MAU.
+        if (ig_dprsr_md.digest_type == 1) {
+            smac_digest.pack({
+                hdr.ethernet.src_mac,
+                (bit<16>)meta.ingress_port
+            });
+        }
+
         /* For Standard and INT Packets */
         packet.emit(hdr.ethernet);
         packet.emit(hdr.arp);
@@ -358,10 +411,6 @@ control TpsAggEgress(
     apply {
     }
 }
-
-/*************************************************************************
-*************************  D E P A R S E R   *****************************
-*************************************************************************/
 
 control TpsAggEgressDeparser(
     packet_out packet,

--- a/p4/include/tps_consts.p4
+++ b/p4/include/tps_consts.p4
@@ -96,7 +96,7 @@ const bit<3> IPV4_DONT_FRAGMENT = 0x2;
 /* Used for counters and this looks like it should be either compile or runtime configurable */
 const bit<32> MAX_DEVICE_ID = 15;
 /* The drop port to check at the ingress but is this really correct??? */
-const bit<9> DROP_PORT = 511;
+const PortId_t DROP_PORT = 511;
 
 /* Constants for determining BMV2 Packet instance_types */
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_NORMAL        = 0;

--- a/p4/include/tps_headers.p4
+++ b/p4/include/tps_headers.p4
@@ -17,7 +17,7 @@
 /*************************************************************************
 *********************** H E A D E R S  ***********************************
 *************************************************************************/
-typedef bit<9>  egressSpec_t;
+typedef PortId_t egressSpec_t;
 typedef bit<48> macAddr_t;
 typedef bit<32> ip4Addr_t;
 typedef bit<128> ip6Addr_t;
@@ -236,7 +236,7 @@ struct headers {
 
 struct mac_learn_digest {
     bit<48> src_mac;
-    bit<9> ingress_port;
+    PortId_t ingress_port;
 }
 
 struct nat_digest {
@@ -246,7 +246,15 @@ struct nat_digest {
 }
 
 struct metadata {
-    ip4Addr_t  ipv4_addr;
-    ip6Addr_t  ipv6_addr;
-    bit<16>    dst_port;
+    ip4Addr_t ipv4_addr;
+    ip6Addr_t ipv6_addr;
+    bit<16>   dst_port;
+    macAddr_t src_mac;
+    macAddr_t dst_mac;
+    PortId_t  ingress_port;
+}
+
+struct digest_t {
+    macAddr_t src_mac;
+    bit<16>  port;
 }

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -81,7 +81,6 @@
     protocol: "{{ send_protocol | default('UDP') }}"
     int_hdr_df: "{{ log_dir }}/send_int_data-ip-{{ ip_ver }}-proto-{{ protocol }}-ih-{{ hops }}.yml"
     ip_ver: "{{ ip_version | default('4') }}"
-    sender_ip: "{{ sender.ip if ip_ver == '4' else sender.ipv6 }}"
     receiver_ip: "{{ receiver.ip if ip_ver == '4' else receiver.ipv6 }}"
     int_hdr_tmplt: ../templates/send_int_hdr.yml.j2
     receiver_mac: "{{ receiver.mac }}"
@@ -142,7 +141,6 @@
     hops: "{{ int_hops | default(0) }}"
     ip_ver: "{{ ip_version | default('4') }}"
     receiver_log_file: "{{ log_dir }}/{{ receiver_log_filename }}"
-    sender_ip: "{{ sender.ip if ip_ver == '4' else sender.ipv6 }}"
     receiver_ip: "{{ receiver.ip if ip_ver == '4' else receiver.ipv6 }}"
   tasks:
     - debug:

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -84,7 +84,7 @@
     sender_ip: "{{ sender.ip if ip_ver == '4' else sender.ipv6 }}"
     receiver_ip: "{{ receiver.ip if ip_ver == '4' else receiver.ipv6 }}"
     int_hdr_tmplt: ../templates/send_int_hdr.yml.j2
-    switch_mac: "{{ dst_mac | default(switch.mac) }}"
+    receiver_mac: "{{ receiver.mac }}"
   tasks:
     - debug:
         msg: "Generating packets"
@@ -103,10 +103,15 @@
       set_fact:
         send_cmd: >-
           {{ trans_sec_dir }}/trans_sec/device_software/send_packets.py
-          -y {{ send_delay }} -i {{ interval }} -it {{ loops }} -itd {{ loop_delay }}
-          -z {{ sender_intf }} -sa {{ sender_ip }} -r {{ receiver_ip }} -sp {{ send_src_port }}
-          -p {{ send_port }} -f {{ sender_log_file }} -c {{ send_packet_count }} -e {{ sender.mac }}
-          -s {{ switch_mac }} -pr {{ send_protocol }} -m '{{ send_msg }}'
+          -z {{ sender_intf }}
+          -f {{ sender_log_file }}
+          -sp {{ send_src_port }} -p {{ send_port }}
+          -r {{ receiver_ip }} -s {{ receiver_mac }}
+          -m '{{ send_msg }}'
+          -y {{ send_delay }} -i {{ interval }}
+          -it {{ loops }} -itd {{ loop_delay }}
+          -pr {{ send_protocol }}
+          -c {{ send_packet_count }}
 
     - name: Configure for Sending INT Packets
       block:

--- a/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
@@ -49,7 +49,7 @@ hosts:
   inet:
     name: inet
     id: 4
-    ip: 192.168.1.10
+    ip: 10.0.1.5
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}
@@ -60,7 +60,7 @@ hosts:
       - host: core
     ipv6: 0000:0000:0000:0000:0000:0001:0001:0003
     ip_port: any
-    mac: 00:00:00:00:01:02
+    mac: 00:00:00:00:05:01
     type: nas
   ae:
     name: ae
@@ -76,7 +76,7 @@ hosts:
       - host: core
     ipv6: 0000:0000:0000:0000:0000:0002:0001:0003
     ip_port: any
-    mac: 00:00:00:00:05:08
+    mac: 00:00:00:00:05:02
     type: server
 switches:
   aggregate:

--- a/trans_sec/bfruntime_lib/bfrt_switch.py
+++ b/trans_sec/bfruntime_lib/bfrt_switch.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 import logging
-from abc import ABC
+from abc import ABC, abstractmethod
 from threading import Thread
 
 import grpc
@@ -54,95 +54,17 @@ class BFRuntimeSwitch(SwitchConnection, ABC):
         self.digest_thread = Thread(target=self.receive_digests)
 
     def start(self):
+        logger.info('Starting switch - [%s]', self.name)
+        self.interface.clear_all_tables()
         self.add_switch_id()
-        self.start_digest_listeners()
+        self.digest_thread.start()
 
     def stop(self):
-        self.stop_digest_listeners()
+        self.digest_thread.join()
 
-    def start_digest_listeners(self):
-        logger.info('Tofino currently not supporting digests')
-        pass
-
-    def stop_digest_listeners(self):
-        self.interface._tear_down_stream()
-        logger.info('Tofino currently not supporting digests')
-        pass
-
-    def get_table_entry(self, table_name, action_name, match_fields,
-                        action_params, ingress_class=True):
-        raise NotImplementedError
-
-    def add_data_forward(self, dst_mac, ingress_port):
-        raise NotImplementedError
-
-    def del_data_forward(self, dst_mac):
-        raise NotImplementedError
-
-    def add_data_inspection(self, dev_id, dev_mac):
-        raise NotImplementedError
-
-    def del_data_inspection(self, dev_id, dev_mac):
-        raise NotImplementedError
-
-    def set_forwarding_pipeline_config(self, device_config):
-        raise NotImplementedError
-
-    def write_table_entry(self, **kwargs):
-        raise NotImplementedError
-
-    def get_data_forward_macs(self):
-        raise NotImplementedError
-
-    def get_data_inspection_src_mac_keys(self):
-        raise NotImplementedError
-
-    def get_match_values(self, table_name):
-        raise NotImplementedError
-
-    def get_table_entries(self, table_name):
-        raise NotImplementedError
-
-    def read_table_entries(self, table_id=None):
-        raise NotImplementedError
-
-    def write_clone_entries(self, pre_entry):
-        # TODO - determine how to clone on TNA
-        pass
-
-    def delete_clone_entries(self, pre_entry):
-        # TODO - determine how to clone on TNA
-        pass
-
-    def read_counters(self, counter_id=None, index=None):
-        # TODO - determine how to count on TNA
-        raise NotImplementedError
-
-    def reset_counters(self, counter_id=None, index=None):
-        # TODO - determine how to count on TNA
-        raise NotImplementedError
-
-    def write_digest_entry(self, digest_entry):
-        # TODO - determine how to digest on TNA
-        pass
-
-    def digest_list_ack(self, digest_ack):
-        # TODO - determine how to digest on TNA
-        pass
-
-    def digest_list(self):
-        # TODO - determine how to digest on TNA
-        pass
-
-    # TODO - determine if this is available or even necessary on TNA
-    def write_multicast_entry(self, hosts):
-        self.write_arp_flood()
-
-    def write_arp_flood(self):
-        """
-        arp_flood_t has not been implemented in core_tna.p4
-        :return:
-        """
+    @abstractmethod
+    def receive_digests(self):
+        logger.info('Received digest')
         pass
 
     def get_table(self, name):

--- a/trans_sec/bfruntime_lib/core_switch.py
+++ b/trans_sec/bfruntime_lib/core_switch.py
@@ -60,10 +60,16 @@ class CoreSwitch(BFRuntimeSwitch):
         logger.info('Instantiating BFRT CoreSwitch')
         super(self.__class__, self).__init__(sw_info, client_id, is_master)
 
-    def start(self, **kwargs):
+    def start(self):
         super(self.__class__, self).start()
         self.__set_table_field_annotations()
         self.write_clone_entries(self.sw_info['clone_egress'])
+
+    def receive_digests(self):
+        """
+        Runnable method for self.digest_thread
+        """
+        pass
 
     def __set_table_field_annotations(self):
         df_table = self.get_table(data_fwd_tbl)
@@ -103,7 +109,7 @@ class CoreSwitch(BFRuntimeSwitch):
             ], '$normal')]
         )
 
-    def delete_clone_entries(self, port, mirror_tbl_key=1):
+    def delete_clone_entries(self, mirror_tbl_key=1):
         mirror_cfg_table = self.get_table("$mirror.cfg")
         mirror_cfg_table.entry_del([
             mirror_cfg_table.make_key([KeyTuple('$sid', mirror_tbl_key)])])

--- a/trans_sec/controller/ddos_sdn_controller.py
+++ b/trans_sec/controller/ddos_sdn_controller.py
@@ -65,6 +65,7 @@ class DdosSdnController:
         logger.info('Stopping SDN controller')
         self.running = False
         self.http_server.stop()
+        self.drop_rpt_thread.join()
 
     def create_drop_report(self):
         while True:

--- a/trans_sec/device_software/receive_packets.py
+++ b/trans_sec/device_software/receive_packets.py
@@ -91,6 +91,8 @@ def __log_packet(packet, int_hops):
 
 def __log_std_packet(ether_pkt, ip_pkt, ip_proto, pkt_len):
     logger.info('Protocol to parse - [%s]', ip_proto)
+    logger.debug('IP class - [%s]', ip_pkt.__class__)
+
     if ip_proto == trans_sec.consts.UDP_PROTO:
         logger.info('Parsing UDP Packet')
         tcp_udp_pkt = UDP(_pkt=ip_pkt.payload)
@@ -98,10 +100,6 @@ def __log_std_packet(ether_pkt, ip_pkt, ip_proto, pkt_len):
         logger.info('Parsing TCP Packet')
         tcp_udp_pkt = TCP(_pkt=ip_pkt.payload)
         logger.debug('TCP flags - [%s]', tcp_udp_pkt.flags)
-        logger.debug('IP class - [%s]', ip_pkt.__class__)
-        if tcp_udp_pkt.flags != 0x2 and isinstance(ip_pkt, IP):
-            logger.debug('TCP flags [%s] not 2, skipping', tcp_udp_pkt.flags)
-            return
     else:
         logger.debug('Nothing to log, protocol - [%s] is unsupported',
                      ip_proto)

--- a/trans_sec/device_software/send_packets.py
+++ b/trans_sec/device_software/send_packets.py
@@ -205,6 +205,7 @@ def __gen_int_pkt(args, ip_ver, src_mac):
     int_hops = len(int_data['meta'])
     shim_len = 4 + 3 + int_hops - 1
     logger.info('Int data to add to packet - [%s]', int_data)
+    udp_int_len = None
     # TODO - Find a better way to calculate PAYLOAD_LEN using args.msg
     if args.protocol == 'UDP':
         udp_int_len = trans_sec.consts.UDP_INT_HDR_LEN + (shim_len * 4) \


### PR DESCRIPTION
#### What does this PR do?
Fixes #286 
Implements digest in aggregate_tna.p4 and bfruntime_lib/aggregate_switch.py to enter return path entries into the data_forward_t table, which should allow for TCP traffic.
#### Do you have any concerns with this PR?
We will need to create some tests that exercise two-way communication (see #301)
We may need to implement aging of the entries (see #300)
#### How can the reviewer verify this PR?
Ensure CI completes successfully
#### Any background context you want to provide?
TCP support is important to support and this is the first step
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? Created #301 to address
