### PR TITLE
Arp multicast support

### DIFF
--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -315,9 +315,11 @@ control TpsAggIngress(
 
         // Basic forwarding and drop logic
         if (data_drop_t.apply().miss) {
-            if (hdr.arp.isValid()) {
+            if (hdr.arp.isValid() && hdr.arp.opcode == (bit<16>)0x1) {
                 ig_dprsr_md.digest_type = DIGEST_TYPE_ARP;
-                data_forward(1);
+                if (ig_intr_md.ingress_port != 0x1) {
+                    data_forward(1);
+                }
             } else {
                 if (data_forward_t.apply().miss) {
                 /*
@@ -332,7 +334,9 @@ control TpsAggIngress(
                         if (src_miss == true || src_move != 0) {
                             ig_dprsr_md.digest_type = DIGEST_TYPE_FWD;
                         }
-                        data_forward(1);
+                        if (ig_intr_md.ingress_port != 0x1) {
+                            data_forward(1);
+                        }
                     }
                 }
             }

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -160,6 +160,7 @@ control TpsAggIngress(
             data_forward;
         }
         size = TABLE_SIZE;
+        default_action = data_forward(1);
     }
 
     action data_drop() {
@@ -294,20 +295,21 @@ control TpsAggIngress(
             add_switch_id_t.apply();
         } else {
             // Add IP & Protocol specific data to new INT data
-            if (data_inspection_t.apply().hit) {
-                if (hdr.udp_int.isValid()) {
-                    insert_udp_int_for_udp();
-                }
-                if (hdr.ipv4.isValid()) {
-                    data_inspect_packet_ipv4();
-                    if (hdr.tcp.isValid()) {
-                        insert_udp_int_for_tcp_ipv4();
+            if (! hdr.arp.isValid()) {
+                if (data_inspection_t.apply().hit) {
+                    if (hdr.udp_int.isValid()) {
+                        insert_udp_int_for_udp();
                     }
-                }
-                else if (hdr.ipv6.isValid()) {
-                    data_inspect_packet_ipv6();
-                    if (hdr.tcp.isValid()) {
-                        insert_udp_int_for_tcp_ipv6();
+                    if (hdr.ipv4.isValid()) {
+                        data_inspect_packet_ipv4();
+                        if (hdr.tcp.isValid()) {
+                            insert_udp_int_for_tcp_ipv4();
+                        }
+                    } else if (hdr.ipv6.isValid()) {
+                        data_inspect_packet_ipv6();
+                        if (hdr.tcp.isValid()) {
+                            insert_udp_int_for_tcp_ipv6();
+                        }
                     }
                 }
             }
@@ -315,27 +317,19 @@ control TpsAggIngress(
 
         // Basic forwarding and drop logic
         if (data_drop_t.apply().miss) {
-            if (hdr.arp.isValid() && hdr.arp.opcode == (bit<16>)0x1) {
-                ig_dprsr_md.digest_type = DIGEST_TYPE_ARP;
-                if (ig_intr_md.ingress_port != 0x1) {
-                    data_forward(1);
-                }
-            } else {
-                if (data_forward_t.apply().miss) {
-                /*
-                 * Send a digest if MAC address is unknown or if it is known
-                 * but attached to a different port as long as it does not come
-                 * in port 1, which should only be a switch. Nodes should be
-                 * plugged into the others.
-                 */
+            if (hdr.arp.isValid() && hdr.arp.opcode == (bit<16>)0x1
+                    && ig_intr_md.ingress_port == (bit<9>)0x1) {
+                // ARP Request - multicast out to all configured nodes
+                ig_tm_md.mcast_grp_a = (bit<16>)0x1;
+            } else if (data_forward_t.apply().miss) {
+                if (hdr.arp.isValid() && hdr.arp.opcode == (bit<16>)0x1
+                        && ig_intr_md.ingress_port != (bit<9>)0x1) {
+                    ig_dprsr_md.digest_type = DIGEST_TYPE_ARP;
+                } else {
                     if (ig_intr_md.ingress_port > 1) {
-                        // Send to NB switch at port 1
                         smac.apply();
                         if (src_miss == true || src_move != 0) {
                             ig_dprsr_md.digest_type = DIGEST_TYPE_FWD;
-                        }
-                        if (ig_intr_md.ingress_port != 0x1) {
-                            data_forward(1);
                         }
                     }
                 }

--- a/p4/include/tps_consts.p4
+++ b/p4/include/tps_consts.p4
@@ -100,7 +100,6 @@ const PortId_t DROP_PORT = 511;
 
 /* Digest constants */
 const bit<3> DIGEST_TYPE_ARP = 0x1;
-const bit<3> DIGEST_TYPE_FWD = 0x2;
 
 /* Constants for determining BMV2 Packet instance_types */
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_NORMAL        = 0;

--- a/p4/include/tps_consts.p4
+++ b/p4/include/tps_consts.p4
@@ -98,6 +98,10 @@ const bit<32> MAX_DEVICE_ID = 15;
 /* The drop port to check at the ingress but is this really correct??? */
 const PortId_t DROP_PORT = 511;
 
+/* Digest constants */
+const bit<3> DIGEST_TYPE_ARP = 0x1;
+const bit<3> DIGEST_TYPE_FWD = 0x2;
+
 /* Constants for determining BMV2 Packet instance_types */
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_NORMAL        = 0;
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_INGRESS_CLONE = 1;

--- a/playbooks/general/setup_source.yml
+++ b/playbooks/general/setup_source.yml
@@ -26,6 +26,7 @@
         update_cache: yes
         name:
           - python3-pip
+          - arping
       register: apt_rc
       retries: 3
       delay: 10

--- a/playbooks/scenarios/aggregate/data-drop.yml
+++ b/playbooks/scenarios/aggregate/data-drop.yml
@@ -27,9 +27,9 @@
     rec_host: "{{ remote_rec_host }}"
     send_port: 4321
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: aggregate-tun1
     dst_mac: "{{ receiver['mac'] }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"

--- a/playbooks/scenarios/aggregate/data-forward.yml
+++ b/playbooks/scenarios/aggregate/data-forward.yml
@@ -26,9 +26,9 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host  }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: aggregate-tun1
     dst_mac: "{{ receiver['mac'] }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
@@ -51,9 +51,9 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: aggregate-tun1
     dst_mac: "{{ receiver['mac'] }}"
     # For sending INT packets on the #1 of 3 send/receive iteration
     sr_data_inspection_int:

--- a/playbooks/scenarios/aggregate/data-inspection.yml
+++ b/playbooks/scenarios/aggregate/data-inspection.yml
@@ -24,9 +24,9 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: aggregate-tun1
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"

--- a/playbooks/scenarios/core/data-forward.yml
+++ b/playbooks/scenarios/core/data-forward.yml
@@ -25,9 +25,9 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: core-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
@@ -50,9 +50,9 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: core-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     sr_data_inspection_int:
       - switch_id: 1002

--- a/playbooks/scenarios/core/data-inspection.yml
+++ b/playbooks/scenarios/core/data-inspection.yml
@@ -25,9 +25,9 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts.host2 }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: core-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
@@ -63,9 +63,9 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
+    sender_intf_name: core-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"

--- a/playbooks/scenarios/gateway/data-drop.yml
+++ b/playbooks/scenarios/gateway/data-drop.yml
@@ -27,9 +27,7 @@
     rec_host: "{{ remote_rec_host }}"
     send_port: 4321
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
         body:

--- a/playbooks/scenarios/gateway/data-forward.yml
+++ b/playbooks/scenarios/gateway/data-forward.yml
@@ -24,9 +24,7 @@
     send_host: host1
     rec_host: host2
     sender: "{{ topo_dict.hosts[send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
         body:

--- a/playbooks/scenarios/gateway/data-inspection.yml
+++ b/playbooks/scenarios/gateway/data-inspection.yml
@@ -26,9 +26,7 @@
     send_host: "{{ remote_send_host }}"
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    send_sw_port: "{{ topo_dict.links[0].south_facing_port }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    rec_sw_port: "{{ topo_dict.links[1].north_facing_port }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
         body:

--- a/playbooks/scenarios/general/arping.yml
+++ b/playbooks/scenarios/general/arping.yml
@@ -34,12 +34,3 @@
     - name: Wait a few seconds
       pause:
         seconds: 5
-
-#    - name: Discover L2 path to hosts once more
-#      command: "{{ arp_command }}"
-#      register: arp_cmd_out
-#      failed_when: arp_cmd_out.rc == 0 or arp_cmd.rc > 1
-#
-#    - name: Wait a couple more seconds
-#      pause:
-#        seconds: 2

--- a/playbooks/scenarios/general/arping.yml
+++ b/playbooks/scenarios/general/arping.yml
@@ -18,9 +18,15 @@
   gather_facts: no
   become: yes
   tasks:
+    - name: Manually create ARP cache entry
+      command: "arp -s {{ receiver.ip }} {{ receiver.mac }}"
+
+# TODO/FIXME - Determine why the dummy interface does not create the proper
+# ARP cache entry with the reply on the dummy interfaces being created with
+# the tunnel/nic config routines execute
     - name: Create ARP command
       set_fact:
-        arp_command: "arping -c 5 -I {{ send_host }}-eth0 {{ receiver.ip }}"
+        arp_command: "arping -c 5 {{ receiver.ip }}"
 
     - name: The arping command
       debug:
@@ -28,5 +34,3 @@
 
     - name: Discover L2 path to hosts
       command: "{{ arp_command }}"
-      register: arp_cmd_out
-      failed_when: arp_cmd_out.rc > 2

--- a/playbooks/scenarios/general/arping.yml
+++ b/playbooks/scenarios/general/arping.yml
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Discover path
+- hosts: "{{ send_host }}"
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Create ARP command
+      set_fact:
+        arp_command: "arping -c 2 -I {{ send_host }}-eth0 {{ receiver.ip }}"
+
+    - name: The arping command
+      debug:
+        var: arp_command
+
+    - name: Discover L2 path to hosts
+      command: "{{ arp_command }}"
+      register: arp_cmd_out
+      failed_when: arp_cmd_out.rc > 2
+
+    - name: Wait a few seconds
+      pause:
+        seconds: 5
+
+#    - name: Discover L2 path to hosts once more
+#      command: "{{ arp_command }}"
+#      register: arp_cmd_out
+#      failed_when: arp_cmd_out.rc == 0 or arp_cmd.rc > 1
+#
+#    - name: Wait a couple more seconds
+#      pause:
+#        seconds: 2

--- a/playbooks/scenarios/general/data_drop_basic.yml
+++ b/playbooks/scenarios/general/data_drop_basic.yml
@@ -29,6 +29,7 @@
             body: "{{ item.body }}"
             status_code: "{{ item.ok_status | default('200') }}"
           with_items: "{{ data_forwards }}"
+      when: data_forwards is defined
 
 # Sending UDP packets expect all to be received
 - import_playbook: ../test_cases/send_receive.yml
@@ -103,3 +104,4 @@
         body: "{{ item.body }}"
         status_code: "{{ item.ok_status | default('200') }}"
       with_items: "{{ data_forwards }}"
+      when: data_forwards is defined

--- a/playbooks/scenarios/general/data_drop_basic.yml
+++ b/playbooks/scenarios/general/data_drop_basic.yml
@@ -14,7 +14,7 @@
 # one will be demonstrating dropped packets
 ---
 # Add table entries into data_forward_t tables
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - block:
@@ -43,7 +43,7 @@
     max_received_packet_count: "{{ send_packet_count }}"
 
 # Start packet mitigation
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - name: Start mitigation with body {{ attack.body }} to {{ attack.url }}
@@ -68,7 +68,7 @@
     max_received_packet_count: 0
 
 # Stop packet mitigation
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - name: Stop mitigation with body {{ attack.body }} to {{ attack.url }}
@@ -92,7 +92,7 @@
     max_received_packet_count: "{{ send_packet_count }}"
 
 # Delete table entries from data_forward_t tables
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - name: Delete data forward table

--- a/playbooks/scenarios/general/data_forward_basic.yml
+++ b/playbooks/scenarios/general/data_forward_basic.yml
@@ -14,7 +14,7 @@
 # one will be demonstrating dropped packets
 ---
 # Add table entries into data_forward_t tables
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - block:
@@ -43,7 +43,7 @@
     max_received_packet_count: "{{ send_packet_count }}"
 
 # Delete table entries from data_forward_t tables
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - name: Delete data forward table

--- a/playbooks/scenarios/general/data_forward_basic.yml
+++ b/playbooks/scenarios/general/data_forward_basic.yml
@@ -21,7 +21,8 @@
         - name: Data forward structure
           debug:
             var: data_forwards
-        - name: Insert data forward table
+
+        - name: Insert data forward table entries
           uri:
             url: "{{ item.url }}"
             method: POST
@@ -29,6 +30,7 @@
             body: "{{ item.body }}"
             status_code: "{{ item.ok_status | default('200') }}"
           with_items: "{{ data_forwards }}"
+      when: data_forwards is defined
 
 ## Sending UDP packets expect all to be received
 - import_playbook: ../test_cases/send_receive.yml
@@ -46,7 +48,7 @@
 - hosts: controller
   gather_facts: no
   tasks:
-    - name: Delete data forward table
+    - name: Delete data forward table entries
       uri:
         url: "{{ item.url }}"
         method: DELETE
@@ -54,3 +56,4 @@
         body: "{{ item.body }}"
         status_code: "{{ item.ok_status | default('200') }}"
       with_items: "{{ data_forwards }}"
+      when: data_forwards is defined

--- a/playbooks/scenarios/lab_trial/all-data-drop.yml
+++ b/playbooks/scenarios/lab_trial/all-data-drop.yml
@@ -13,20 +13,29 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover path
-- hosts: "{{ send_host }}"
-  gather_facts: no
-  become: yes
-  tasks:
-    - name: Create ARP command
-      set_fact:
-        arp_command: "arping -c 5 -I {{ send_host }}-eth0 {{ receiver.ip }}"
+# Discover Forwarding Paths
+- import_playbook: discover-paths.yml
 
-    - name: The arping command
-      debug:
-        var: arp_command
+# Data Drop scenarios for UDP and IPv4
+- import_playbook: data-drop.yml
+  vars:
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 4
 
-    - name: Discover L2 path to hosts
-      command: "{{ arp_command }}"
-      register: arp_cmd_out
-      failed_when: arp_cmd_out.rc > 2
+# Data Drop scenarios for UDP and IPv6
+- import_playbook: data-drop.yml
+  vars:
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 6
+
+# Data Drop scenarios for TCP and IPv4
+- import_playbook: data-drop.yml
+  vars:
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 4
+
+# Data Drop scenarios for TCP and IPv6
+- import_playbook: data-drop.yml
+  vars:
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 6

--- a/playbooks/scenarios/lab_trial/all-data-drop.yml
+++ b/playbooks/scenarios/lab_trial/all-data-drop.yml
@@ -21,21 +21,25 @@
   vars:
     scenario_send_protocol: UDP
     scenario_send_ip_version: 4
+    arp_discovery: True
 
 # Data Drop scenarios for UDP and IPv6
 - import_playbook: data-drop.yml
   vars:
     scenario_send_protocol: UDP
     scenario_send_ip_version: 6
+    arp_discovery: True
 
 # Data Drop scenarios for TCP and IPv4
 - import_playbook: data-drop.yml
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 4
+    arp_discovery: True
 
 # Data Drop scenarios for TCP and IPv6
 - import_playbook: data-drop.yml
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 6
+    arp_discovery: True

--- a/playbooks/scenarios/lab_trial/all-data-drop.yml
+++ b/playbooks/scenarios/lab_trial/all-data-drop.yml
@@ -13,8 +13,8 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover Forwarding Paths
-- import_playbook: discover-paths.yml
+# Refresh lab_trial environment config
+- import_playbook: restart-lab_trial.yml
 
 # Data Drop scenarios for UDP and IPv4
 - import_playbook: data-drop.yml

--- a/playbooks/scenarios/lab_trial/all-data-forward.yml
+++ b/playbooks/scenarios/lab_trial/all-data-forward.yml
@@ -13,20 +13,29 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover path
-- hosts: "{{ send_host }}"
-  gather_facts: no
-  become: yes
-  tasks:
-    - name: Create ARP command
-      set_fact:
-        arp_command: "arping -c 5 -I {{ send_host }}-eth0 {{ receiver.ip }}"
+# Discover Forwarding Paths
+- import_playbook: discover-paths.yml
 
-    - name: The arping command
-      debug:
-        var: arp_command
+# Data Forward scenarios for UDP and IPv4
+- import_playbook: data-forward.yml
+  vars:
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 4
 
-    - name: Discover L2 path to hosts
-      command: "{{ arp_command }}"
-      register: arp_cmd_out
-      failed_when: arp_cmd_out.rc > 2
+# Data Forward scenarios for UDP and IPv6
+- import_playbook: data-forward.yml
+  vars:
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 6
+
+# Data Forward scenarios for TCP and IPv4
+- import_playbook: data-forward.yml
+  vars:
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 4
+
+# Data Forward scenarios for TCP and IPv6
+- import_playbook: data-forward.yml
+  vars:
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 6

--- a/playbooks/scenarios/lab_trial/all-data-forward.yml
+++ b/playbooks/scenarios/lab_trial/all-data-forward.yml
@@ -13,8 +13,8 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover Forwarding Paths
-- import_playbook: discover-paths.yml
+# Refresh lab_trial environment config
+- import_playbook: restart-lab_trial.yml
 
 # Data Forward scenarios for UDP and IPv4
 - import_playbook: data-forward.yml

--- a/playbooks/scenarios/lab_trial/all-data-forward.yml
+++ b/playbooks/scenarios/lab_trial/all-data-forward.yml
@@ -21,21 +21,25 @@
   vars:
     scenario_send_protocol: UDP
     scenario_send_ip_version: 4
+    arp_discovery: True
 
 # Data Forward scenarios for UDP and IPv6
 - import_playbook: data-forward.yml
   vars:
     scenario_send_protocol: UDP
     scenario_send_ip_version: 6
+    arp_discovery: True
 
 # Data Forward scenarios for TCP and IPv4
 - import_playbook: data-forward.yml
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 4
+    arp_discovery: True
 
 # Data Forward scenarios for TCP and IPv6
 - import_playbook: data-forward.yml
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 6
+    arp_discovery: True

--- a/playbooks/scenarios/lab_trial/all-data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/all-data-inspection.yml
@@ -13,20 +13,29 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover path
-- hosts: "{{ send_host }}"
-  gather_facts: no
-  become: yes
-  tasks:
-    - name: Create ARP command
-      set_fact:
-        arp_command: "arping -c 5 -I {{ send_host }}-eth0 {{ receiver.ip }}"
+# Discover Forwarding Paths
+- import_playbook: discover-paths.yml
 
-    - name: The arping command
-      debug:
-        var: arp_command
+# Data Inspection scenarios for UDP and IPv4
+- import_playbook: data-inspection.yml
+  vars:
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 4
 
-    - name: Discover L2 path to hosts
-      command: "{{ arp_command }}"
-      register: arp_cmd_out
-      failed_when: arp_cmd_out.rc > 2
+# Data Inspection scenarios for UDP and IPv6
+- import_playbook: data-inspection.yml
+  vars:
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 6
+
+# Data Inspection scenarios for TCP and IPv4
+- import_playbook: data-inspection.yml
+  vars:
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 4
+
+# Data Inspection scenarios for TCP and IPv6
+- import_playbook: data-inspection.yml
+  vars:
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 6

--- a/playbooks/scenarios/lab_trial/all-data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/all-data-inspection.yml
@@ -13,8 +13,8 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover Forwarding Paths
-- import_playbook: discover-paths.yml
+# Refresh lab_trial environment config
+- import_playbook: restart-lab_trial.yml
 
 # Data Inspection scenarios for UDP and IPv4
 - import_playbook: data-inspection.yml

--- a/playbooks/scenarios/lab_trial/all-data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/all-data-inspection.yml
@@ -21,21 +21,25 @@
   vars:
     scenario_send_protocol: UDP
     scenario_send_ip_version: 4
+    arp_discovery: True
 
 # Data Inspection scenarios for UDP and IPv6
 - import_playbook: data-inspection.yml
   vars:
     scenario_send_protocol: UDP
     scenario_send_ip_version: 6
+    arp_discovery: True
 
 # Data Inspection scenarios for TCP and IPv4
 - import_playbook: data-inspection.yml
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 4
+    arp_discovery: True
 
 # Data Inspection scenarios for TCP and IPv6
 - import_playbook: data-inspection.yml
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 6
+    arp_discovery: True

--- a/playbooks/scenarios/lab_trial/all-pkt-flood.yml
+++ b/playbooks/scenarios/lab_trial/all-pkt-flood.yml
@@ -1,0 +1,69 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Discover Forwarding Paths
+- import_playbook: discover-paths.yml
+
+# Discover SB path
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: inet
+    rec_host: host1
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+# Data Inspection scenarios for UDP and IPv4
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 4
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_send_loops: 2
+    di_send_loop_delay: 10
+
+# Data Inspection scenarios for UDP and IPv6 with AE for testing dropping packets
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 6
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_send_loops: 2
+    di_send_loop_delay: 10
+
+# Data Inspection scenarios for TCP and IPv4 with AE for testing dropping packets
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 4
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_send_loops: 2
+    di_send_loop_delay: 10
+
+# Data Inspection scenarios for TCP and IPv6 with AE for testing dropping packets
+- import_playbook: data-inspection.yml
+  vars:
+    di_log_prfx: di-ae-dd
+    scenario_send_protocol: TCP
+    scenario_send_ip_version: 6
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_send_loops: 2
+    di_send_loop_delay: 10

--- a/playbooks/scenarios/lab_trial/all-pkt-flood.yml
+++ b/playbooks/scenarios/lab_trial/all-pkt-flood.yml
@@ -13,17 +13,8 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover Forwarding Paths
-- import_playbook: discover-paths.yml
-
-# Discover SB path
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: inet
-    rec_host: host1
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-    arp_discovery: True
+# Refresh lab_trial environment config
+- import_playbook: restart-lab_trial.yml
 
 # Data Inspection scenarios for UDP and IPv4
 - import_playbook: data-inspection.yml

--- a/playbooks/scenarios/lab_trial/all-pkt-flood.yml
+++ b/playbooks/scenarios/lab_trial/all-pkt-flood.yml
@@ -23,6 +23,7 @@
     send_host: inet
     rec_host: host1
     receiver: "{{ topo_dict.hosts[rec_host] }}"
+    arp_discovery: True
 
 # Data Inspection scenarios for UDP and IPv4
 - import_playbook: data-inspection.yml
@@ -34,6 +35,7 @@
     di_min_rec_packet_count: 99
     di_send_loops: 2
     di_send_loop_delay: 10
+    arp_discovery: True
 
 # Data Inspection scenarios for UDP and IPv6 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -45,6 +47,7 @@
     di_min_rec_packet_count: 99
     di_send_loops: 2
     di_send_loop_delay: 10
+    arp_discovery: True
 
 # Data Inspection scenarios for TCP and IPv4 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -56,6 +59,7 @@
     di_min_rec_packet_count: 99
     di_send_loops: 2
     di_send_loop_delay: 10
+    arp_discovery: True
 
 # Data Inspection scenarios for TCP and IPv6 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -67,3 +71,4 @@
     di_min_rec_packet_count: 99
     di_send_loops: 2
     di_send_loop_delay: 10
+    arp_discovery: True

--- a/playbooks/scenarios/lab_trial/all.yml
+++ b/playbooks/scenarios/lab_trial/all.yml
@@ -13,119 +13,14 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Data Forward scenarios for UDP and IPv4
-- import_playbook: data-forward.yml
-  vars:
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 4
+# Data Forward scenarios
+- import_playbook: all-data-forward.yml
 
-# Data Forward scenarios for UDP and IPv6
-- import_playbook: data-forward.yml
-  vars:
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 6
+# Data Inspection scenarios
+- import_playbook: all-data-inspection.yml
 
-# TODO/FIXME - Fix TCP headers are egressing from core-eth2 with incorrect port values
-# Data Forward scenarios for TCP and IPv4
-- import_playbook: data-forward.yml
-  vars:
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 4
+# Data Drop scenarios
+- import_playbook: all-data-drop.yml
 
-# Data Forward scenarios for TCP and IPv6
-- import_playbook: data-forward.yml
-  vars:
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 6
-
-# Data Inspection scenarios for UDP and IPv4
-- import_playbook: data-inspection.yml
-  vars:
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 4
-
-# Data Inspection scenarios for UDP and IPv6
-- import_playbook: data-inspection.yml
-  vars:
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 6
-
-# Data Inspection scenarios for TCP and IPv4
-- import_playbook: data-inspection.yml
-  vars:
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 4
-
-# Data Inspection scenarios for TCP and IPv6
-- import_playbook: data-inspection.yml
-  vars:
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 6
-
-# Data Drop scenarios for UDP and IPv4
-- import_playbook: data-drop.yml
-  vars:
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 4
-
-# Data Drop scenarios for UDP and IPv6
-- import_playbook: data-drop.yml
-  vars:
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 6
-
-# Data Drop scenarios for TCP and IPv4
-- import_playbook: data-drop.yml
-  vars:
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 4
-
-# Data Drop scenarios for TCP and IPv6
-- import_playbook: data-drop.yml
-  vars:
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 6
-
-# Data Inspection scenarios for UDP and IPv4
-- import_playbook: data-inspection.yml
-  vars:
-    di_log_prfx: di-ae-dd
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 4
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 10
-
-# Data Inspection scenarios for UDP and IPv6 with AE for testing dropping packets
-- import_playbook: data-inspection.yml
-  vars:
-    di_log_prfx: di-ae-dd
-    scenario_send_protocol: UDP
-    scenario_send_ip_version: 6
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 10
-
-# Data Inspection scenarios for TCP and IPv4 with AE for testing dropping packets
-- import_playbook: data-inspection.yml
-  vars:
-    di_log_prfx: di-ae-dd
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 4
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 10
-
-# Data Inspection scenarios for TCP and IPv6 with AE for testing dropping packets
-- import_playbook: data-inspection.yml
-  vars:
-    di_log_prfx: di-ae-dd
-    scenario_send_protocol: TCP
-    scenario_send_ip_version: 6
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 10
+# Packet Flood scenarios
+- import_playbook: all-pkt-flood.yml

--- a/playbooks/scenarios/lab_trial/configure_switches-lab_trial.yml
+++ b/playbooks/scenarios/lab_trial/configure_switches-lab_trial.yml
@@ -1,0 +1,59 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Call POST on all WS calls
+- hosts: controller
+  gather_facts: no
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    aggregate: "{{ topo_dict.switches.aggregate }}"
+    core: "{{ topo_dict.switches.core }}"
+    host1: "{{ topo_dict.hosts.host1 }}"
+    host2: "{{ topo_dict.hosts.host2 }}"
+    inet: "{{ topo_dict.hosts.inet }}"
+    ae: "{{ topo_dict.hosts.ae }}"
+    ws_calls:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/setupTelemRpt"
+        body:
+          device_id: "{{ core.id }}"
+          switch_mac: "{{ core.mac }}"
+          port: 555
+          ae_ip: "{{ ae_ip }}"
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+        body:
+          device_id: "{{ aggregate.id }}"
+          switch_mac: "{{ aggregate.mac }}"
+          device_mac: "{{ host1.mac }}"
+        ok_status: 201
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+        body:
+          device_id: "{{ aggregate.id }}"
+          switch_mac: "{{ aggregate.mac }}"
+          device_mac: "{{ host2.mac }}"
+        ok_status: 201
+  tasks:
+    - name: Web service calls to make
+      debug:
+        var: ws_calls
+
+    - name: POST WS calls
+      uri:
+        url: "{{ item.url }}"
+        method: POST
+        body_format: "{{ item.body_format | default('json') }}"
+        body: "{{ item.body }}"
+        status_code: "{{ item.ok_status | default('200') }}"
+      with_items: "{{ ws_calls }}"

--- a/playbooks/scenarios/lab_trial/data-drop.yml
+++ b/playbooks/scenarios/lab_trial/data-drop.yml
@@ -13,14 +13,6 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover path
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: host1
-    rec_host: inet
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-
 # Basic Data Drop scenario for the lab trial
 - import_playbook: ../general/data_drop_basic.yml
   vars:

--- a/playbooks/scenarios/lab_trial/data-drop.yml
+++ b/playbooks/scenarios/lab_trial/data-drop.yml
@@ -13,6 +13,13 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
+# Discover path
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: host1
+    rec_host: inet
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
 
 # Basic Data Drop scenario for the lab trial
 - import_playbook: ../general/data_drop_basic.yml
@@ -30,14 +37,6 @@
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     dst_mac: "{{ receiver.mac }}"
-    data_forwards:
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-        body:
-          device_id: "{{ switch2.id }}"
-          switch_mac: "{{ switch2.mac }}"
-          dst_mac: "{{ receiver.mac }}"
-          output_port: 2
-        ok_status: 201
     attack:
       url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"
       body:

--- a/playbooks/scenarios/lab_trial/data-drop.yml
+++ b/playbooks/scenarios/lab_trial/data-drop.yml
@@ -28,6 +28,8 @@
     send_port: 4321
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver.mac }}"
     attack:
       url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"

--- a/playbooks/scenarios/lab_trial/data-forward.yml
+++ b/playbooks/scenarios/lab_trial/data-forward.yml
@@ -13,14 +13,6 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover path
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: host1
-    rec_host: inet
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-
 # Basic Data Forward scenario for standard Packets to the inet
 - import_playbook: ../general/data_forward_basic.yml
   vars:

--- a/playbooks/scenarios/lab_trial/data-forward.yml
+++ b/playbooks/scenarios/lab_trial/data-forward.yml
@@ -13,6 +13,13 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
+# Discover path
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: host1
+    rec_host: inet
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
 
 # Basic Data Forward scenario for standard Packets to the inet
 - import_playbook: ../general/data_forward_basic.yml
@@ -27,11 +34,3 @@
     sender: "{{ topo_dict.hosts[send_host] }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
     dst_mac: "{{ receiver.mac }}"
-    data_forwards:
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-        body:
-          device_id: "{{ switch2.id }}"
-          switch_mac: "{{ switch2.mac }}"
-          dst_mac: "{{ receiver.mac }}"
-          output_port: 2
-        ok_status: 201

--- a/playbooks/scenarios/lab_trial/data-forward.yml
+++ b/playbooks/scenarios/lab_trial/data-forward.yml
@@ -25,4 +25,6 @@
     rec_host: inet
     sender: "{{ topo_dict.hosts[send_host] }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver.mac }}"

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -27,6 +27,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
@@ -58,6 +60,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts.inet }}"
+    sender_intf_name: aggregate-tun1
+    rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -13,6 +13,13 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
+# Discover path
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: host1
+    rec_host: inet
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
 
 # Basic Data Inspection scenario - receiving packets on core-eth2 (non-INT packets)
 - import_playbook: data_inspection_basic.yml
@@ -30,13 +37,6 @@
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-        body:
-          device_id: "{{ switch2.id }}"
-          switch_mac: "{{ switch2.mac }}"
-          dst_mac: "{{ receiver.mac }}"
-          output_port: 2
-        ok_status: 201
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
         body:
           device_id: "{{ switch.id }}"
@@ -68,13 +68,6 @@
     receiver: "{{ topo_dict.hosts.inet }}"
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
-        body:
-          device_id: "{{ switch2.id }}"
-          switch_mac: "{{ switch2.mac }}"
-          dst_mac: "{{ receiver.mac }}"
-          output_port: 2
-        ok_status: 201
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
         body:
           device_id: "{{ switch.id }}"

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -30,20 +30,6 @@
     sender_intf_name: aggregate-tun1
     rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
-    ws_calls:
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
-        body:
-          device_id: "{{ switch.id }}"
-          switch_mac: "{{ switch.mac }}"
-          device_mac: "{{ sender.mac }}"
-        ok_status: 201
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/setupTelemRpt"
-        body:
-          device_id: "{{ switch2.id }}"
-          switch_mac: "{{ switch2.mac }}"
-          port: 555
-          ae_ip: "{{ ae_ip }}"
-        ok_status: 201
     sr1_rec_int_hops: 0
 
 # Basic Data Inspection scenario - receiving packets on core-eth3 (INT packets)
@@ -63,18 +49,4 @@
     sender_intf_name: aggregate-tun1
     rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
-    ws_calls:
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
-        body:
-          device_id: "{{ switch.id }}"
-          switch_mac: "{{ switch.mac }}"
-          device_mac: "{{ sender.mac }}"
-        ok_status: 201
-      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/setupTelemRpt"
-        body:
-          device_id: "{{ switch2.id }}"
-          switch_mac: "{{ switch2.mac }}"
-          port: 555
-          ae_ip: "{{ ae_ip }}"
-        ok_status: 201
     sr1_rec_int_hops: 2

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -13,14 +13,6 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Discover path
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: host1
-    rec_host: inet
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-
 # Basic Data Inspection scenario - receiving packets on core-eth2 (non-INT packets)
 - import_playbook: data_inspection_basic.yml
   vars:

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -31,7 +31,8 @@
         - name: Web service calls to make
           debug:
             var: ws_calls
-        - name: Insert data forward table
+
+        - name: POST WS calls
           uri:
             url: "{{ item.url }}"
             method: POST
@@ -39,6 +40,7 @@
             body: "{{ item.body }}"
             status_code: "{{ item.ok_status | default('200') }}"
           with_items: "{{ ws_calls }}"
+      when: ws_calls is defined
 
 # Sending packets expect all to be received with configured INT hops sr1_rec_int_hops
 - import_playbook: ../test_cases/send_receive.yml
@@ -64,7 +66,7 @@
 - hosts: controller
   gather_facts: no
   tasks:
-    - name: Data inspection requests
+    - name: DELETE WS calls
       uri:
         url: "{{ item.url }}"
         method: DELETE
@@ -72,3 +74,4 @@
         body: "{{ item.body }}"
         status_code: "{{ item.ok_status | default('200') }}"
       with_items: "{{ ws_calls }}"
+      when: ws_calls is defined

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -24,7 +24,7 @@
         state: restarted
 
 # Call POST on all WS calls
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - block:
@@ -61,7 +61,7 @@
       ok_status: 201
 
 # Call DELETE on all WS calls
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - name: Data inspection requests

--- a/playbooks/scenarios/lab_trial/discover-paths.yml
+++ b/playbooks/scenarios/lab_trial/discover-paths.yml
@@ -1,0 +1,80 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Discover NB paths
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: host1
+    rec_host: inet
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: host1
+    rec_host: ae
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: host2
+    rec_host: inet
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: host2
+    rec_host: ae
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+# Discover SB paths
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: inet
+    rec_host: host1
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: inet
+    rec_host: host2
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: ae
+    rec_host: host1
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+- import_playbook: ../general/arping.yml
+  vars:
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    send_host: ae
+    rec_host: host2
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+
+- hosts: localhost
+  tasks:
+    - name: Wait a few seconds
+      pause:
+        seconds: 5
+
+

--- a/playbooks/scenarios/lab_trial/discover-paths.yml
+++ b/playbooks/scenarios/lab_trial/discover-paths.yml
@@ -24,22 +24,8 @@
 - import_playbook: ../general/arping.yml
   vars:
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: host1
-    rec_host: ae
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     send_host: host2
     rec_host: inet
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: host2
-    rec_host: ae
     receiver: "{{ topo_dict.hosts[rec_host] }}"
 
 # Discover SB paths
@@ -54,20 +40,6 @@
   vars:
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     send_host: inet
-    rec_host: host2
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: ae
-    rec_host: host1
-    receiver: "{{ topo_dict.hosts[rec_host] }}"
-
-- import_playbook: ../general/arping.yml
-  vars:
-    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-    send_host: ae
     rec_host: host2
     receiver: "{{ topo_dict.hosts[rec_host] }}"
 

--- a/playbooks/scenarios/lab_trial/restart-lab_trial.yml
+++ b/playbooks/scenarios/lab_trial/restart-lab_trial.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Restart all services
+- import_playbook: restart_services-lab_trial.yml
+
+# Discover SB path
+- import_playbook: discover-paths.yml
+
+# Configure the switches
+- import_playbook: configure_switches-lab_trial.yml

--- a/playbooks/scenarios/lab_trial/restart_services-lab_trial.yml
+++ b/playbooks/scenarios/lab_trial/restart_services-lab_trial.yml
@@ -1,0 +1,56 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Restart Switches to clear all and start fresh
+- hosts:
+    - aggregate
+    - core
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Restart tps-tofino-switchd
+      systemd:
+        name: tps-tofino-switchd
+        state: restarted
+
+    - name: Wait for tps-tofino-switchd to open port
+      wait_for:
+        port: "{{ switchd_port | default(50052) }}"
+        timeout: 90
+
+# Restart SDN service to ensure P4 tables are properly setup for the next set of tests
+- hosts: controller
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Restart tps-tofino-sdn
+      systemd:
+        name: tps-tofino-sdn
+        state: restarted
+
+    - name: Wait for tps-tofino-sdn to open port
+      wait_for:
+        port: "{{ sdn_port | default(9998) }}"
+        timeout: 60
+
+# Restart AE service to ensure moving window gets reset
+- hosts: ae
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Restart tps-tofino-ae
+      systemd:
+        name: tps-tofino-ae
+        state: restarted

--- a/playbooks/scenarios/single_switch/data_inspection_basic.yml
+++ b/playbooks/scenarios/single_switch/data_inspection_basic.yml
@@ -14,7 +14,7 @@
 # one will be demonstrating dropped packets
 ---
 # Call web services for data_forward and setup_telemetry report
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - block:
@@ -31,7 +31,7 @@
           with_items: "{{ ws_calls }}"
 
 # Call web services for data_inspection
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - block:
@@ -61,7 +61,7 @@
     max_received_packet_count: "{{ send_packet_count }}"
 
 # Disable switches for data inspection
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - name: DELETE Data inspection requests
@@ -75,7 +75,7 @@
       when: data_inspections is defined
 
 # Delete table entries from data_forward_t tables
-- hosts: "{{ rec_host }}"
+- hosts: controller
   gather_facts: no
   tasks:
     - name: Call DELETE on ws_calls

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -25,7 +25,8 @@
     receive_timeout: "{{ receiver_timeout_seconds | default(60) }}"
     hops: "{{ int_hops | default(0) }}"
     ip_ver: "{{ ip_version | default('4') }}"
-    receiver_intf: "{{ '%s-eth0' % rec_host }}"
+    receiver_intf: "{{ rec_intf_name | default(None) }}"
+    receiver_ipv4: "{{ rec_ipv4 | default(None) }}"
     receiver_log_file: "{{ log_dir }}/{{ receiver_log_filename }}"
   tasks:
     - debug:
@@ -46,13 +47,32 @@
         path: "{{ receiver_log_file }}"
         state: touch
 
-    - name: Create receive packets command
+    - debug:
+        var: receiver_intf
+    - debug:
+        var: receiver_ipv4
+
+    - name: Create receive packets command with the receiver_intf variable
       set_fact:
         receive_cmd: >
           {{ trans_sec_dir }}/trans_sec/device_software/receive_packets.py
           -i {{ receiver_intf }} -f {{ receiver_log_file }} -d {{ receive_timeout }} -ih {{ hops }}
+      when: receiver_intf is defined and receiver_intf | length > 0
 
-    - debug:
+    - name: Create receive packets command with the receiver_ipv4 variable
+      set_fact:
+        receive_cmd: >
+          {{ trans_sec_dir }}/trans_sec/device_software/receive_packets.py
+          -dip4 {{ receiver_ipv4 }} -f {{ receiver_log_file }} -d {{ receive_timeout }} -ih {{ hops }}
+      when: receiver_ipv4 is defined and receiver_ipv4 | length > 0
+
+    - name: Fail when receive command was not created
+      fail:
+        msg: 'Receive command could not be generated'
+      when: receive_cmd is not defined or receive_cmd | length < 1
+
+    - name: The receive command
+      debug:
         var: receive_cmd
 
     - name: >
@@ -76,7 +96,7 @@
     loops: "{{ send_loops | default(1) }}"
     loop_delay: "{{ send_loop_delay | default(0) }}"
     hops: "{{ int_hops | default(0) }}"
-    sender_intf: "{{ '%s-eth0' % send_host }}"
+    sender_intf: "{{ sender_intf_name | default(None) }}"
     sender_log_file: "{{ log_dir }}/{{ sender_log_filename }}"
     protocol: "{{ send_protocol | default('UDP') }}"
     int_hdr_df: "{{ log_dir }}/send_int_data-ip-{{ ip_ver }}-proto-{{ protocol }}-ih-{{ hops }}.yml"

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -82,8 +82,9 @@
     int_hdr_df: "{{ log_dir }}/send_int_data-ip-{{ ip_ver }}-proto-{{ protocol }}-ih-{{ hops }}.yml"
     ip_ver: "{{ ip_version | default('4') }}"
     receiver_ip: "{{ receiver.ip if ip_ver == '4' else receiver.ipv6 }}"
-    int_hdr_tmplt: ../templates/send_int_hdr.yml.j2
     receiver_mac: "{{ receiver.mac }}"
+    receiver_ipv4: "{{ receiver.ip }}"
+    int_hdr_tmplt: ../templates/send_int_hdr.yml.j2
   tasks:
     - debug:
         msg: "Generating packets"
@@ -105,12 +106,22 @@
           -z {{ sender_intf }}
           -f {{ sender_log_file }}
           -sp {{ send_src_port }} -p {{ send_port }}
-          -r {{ receiver_ip }} -s {{ receiver_mac }}
+          -r {{ receiver_ip }}
           -m '{{ send_msg }}'
           -y {{ send_delay }} -i {{ interval }}
           -it {{ loops }} -itd {{ loop_delay }}
           -pr {{ send_protocol }}
           -c {{ send_packet_count }}
+
+    - name: Add receiver ipv4 to send_packets.py call for dst_mac ARP table lookup
+      set_fact:
+        send_cmd: "{{ send_cmd }} -dip4 {{ receiver_ipv4 }}"
+      when: arp_discovery is defined and arp_discovery|bool
+
+    - name: Add known dst_mac to send_packets.py call
+      set_fact:
+        send_cmd: "{{ send_cmd }} -s {{ receiver_mac }}"
+      when: arp_discovery is not defined or not arp_discovery|bool
 
     - name: Configure for Sending INT Packets
       block:

--- a/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
@@ -49,7 +49,7 @@ hosts:
   inet:
     name: inet
     id: 4
-    ip: 10.0.1.5
+    ip: 192.168.1.10
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}
@@ -65,7 +65,7 @@ hosts:
   ae:
     name: ae
     id: 13
-    ip: 10.0.1.9
+    ip: 192.168.1.14
 {% if ae_user is defined or host_user is defined %}
     user: {{ ae_user | default(host_user) }}
 {% endif %}

--- a/playbooks/tofino/templates/topology_template-single_switch.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-single_switch.yaml.j2
@@ -67,6 +67,8 @@ switches:
     type: {{ p4_prog }}
     arch: {{ p4_arch }}
     tunnels:
+      - host: dummy
+        switch_port: 1
       - host: host1
         switch_port: 4
       - host: host2

--- a/playbooks/tofino/tunnel/gre_tunnel_tasks.yml
+++ b/playbooks/tofino/tunnel/gre_tunnel_tasks.yml
@@ -96,45 +96,11 @@
       command: "ip link set {{ tunnel1 }} up"
   when: item.host == "dummy"
 
-- name: Setup host communication ports to send/receive packets
+- name: Setup host tunnel to switch port with expected IP/MAC
   block:
-    - name: Set interface name for {{ this_host.name }}
-      set_fact:
-        mirrored_host_intf: "{{ this_host.name }}-eth0"
-
-    - name: Delete final output port {{ mirrored_host_intf }} if exists
-      command: "ip link del {{ mirrored_host_intf }} type dummy"
-      ignore_errors: yes
-
-    - name: Create final output port {{ mirrored_host_intf }}
-      command: "ip link add {{ mirrored_host_intf }} type dummy"
-
     - name: set MAC {{ this_host.mac }} on {{ mirrored_host_intf }}
-      command: "ip link set dev {{ mirrored_host_intf }} address {{ this_host.mac }}"
+      command: "ip link set dev {{ tunnel1 }} address {{ this_host.mac }}"
 
     - name: Set IP {{ this_host.ip }}/24 on {{ mirrored_host_intf }}
-      command: "ip addr add {{ this_host.ip }}/24 dev {{ mirrored_host_intf }}"
-
-    - name: set host mirrored interface up - {{ mirrored_host_intf }}
-      command: "ip link set {{ mirrored_host_intf }} up"
-
-    - name: activate ARP on interface - {{ mirrored_host_intf }}
-      command: "ip link set dev {{ mirrored_host_intf }} arp on"
-
-    - name: Configure port mirroring for egress traffic
-      command: "tc qdisc add dev {{ mirrored_host_intf }} handle 1: root prio"
-
-    - name: Set qdisc filter for egress traffic directed into tunnel
-      command: >
-        tc filter add dev {{ mirrored_host_intf }} parent 1: protocol all
-        u32 match u32 0 0 action mirred egress mirror dev {{ tunnel1 }}
-
-    - name: Configure port mirroring for ingress traffic
-      command: "tc qdisc add dev {{ tunnel1 }} handle ffff: ingress"
-
-    - name: Set qdisc filter for ingress traffic directed from tunnel
-      command: >
-        tc filter add dev {{ tunnel1 }} parent ffff: protocol all
-        u32 match u32 0 0 action mirred ingress mirror dev {{ mirrored_host_intf }}
+      command: "ip addr add {{ this_host.ip }}/24 dev {{ tunnel1 }}"
   when: item.switch_port is not defined
-

--- a/playbooks/tofino/tunnel/gre_tunnel_tasks.yml
+++ b/playbooks/tofino/tunnel/gre_tunnel_tasks.yml
@@ -82,6 +82,20 @@
       command: "ip link set {{ tunnel1 }} up"
   when: intf_exist is failed and remote_host is defined and remote_host != ""
 
+- name: Dummy Interface "Tunnel"
+  block:
+    - name: Delete dummy interface {{ tunnel1 }} if exists
+      command: "ip link del {{ tunnel1 }} type dummy"
+      ignore_errors: yes
+
+    - name: Create dummy interface {{ tunnel1 }}
+      command: "ip link add {{ tunnel1 }} type dummy"
+
+    # Bring up tunnel
+    - name: set gre tunnel 1 up - {{ tunnel1 }}
+      command: "ip link set {{ tunnel1 }} up"
+  when: item.host == "dummy"
+
 - name: Setup host communication ports to send/receive packets
   block:
     - name: Set interface name for {{ this_host.name }}
@@ -103,6 +117,9 @@
 
     - name: set host mirrored interface up - {{ mirrored_host_intf }}
       command: "ip link set {{ mirrored_host_intf }} up"
+
+    - name: activate ARP on interface - {{ mirrored_host_intf }}
+      command: "ip link set dev {{ mirrored_host_intf }} arp on"
 
     - name: Configure port mirroring for egress traffic
       command: "tc qdisc add dev {{ mirrored_host_intf }} handle 1: root prio"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ flask_restful
 ipaddress
 netaddr
 mock==4.0.2
+python_arptable

--- a/trans_sec/bfruntime_lib/aggregate_switch.py
+++ b/trans_sec/bfruntime_lib/aggregate_switch.py
@@ -87,6 +87,7 @@ class AggregateSwitch(BFRuntimeSwitch):
         while True:
             digest = None
             try:
+                logger.debug('Agg digest iter')
                 digest = self.interface.digest_get()
             except Exception as e:
                 if 'Digest list not received' not in str(e):
@@ -117,18 +118,6 @@ class AggregateSwitch(BFRuntimeSwitch):
                             logger.error(
                                 'Unexpected error processing digest for '
                                 'data_forward_t - [%s]', e)
-                            raise e
-                    try:
-                        self.add_smac(src_mac, port)
-                        logger.debug('Added digest to smac table')
-                    except Exception as e:
-                        if 'ALREADY_EXISTS' in str(e):
-                            logger.debug(
-                                'Not inserting digest entry to smac - [%s]', e)
-                        else:
-                            logger.error(
-                                'Unexpected error processing digest for smac '
-                                '- [%s]', e)
                             raise e
 
     def __set_table_field_annotations(self):


### PR DESCRIPTION
#### What does this PR do?
Fixes #303 and Fixes #316 
Implement ARP digest for insertion of L2 routes to the NB nodes
Removed the manual table entries into data forward from the lab trial tests.
Removed the addition of the switch_ethernet (-s) option denoting the dst_mac value in send_packets.py so the host generating the packets will leverage the dst_mac as in the ARP cache only for the lab_trial scenario tests.
Each NB node has ARP cache entries for all SB nodes and vice versa.

Not certifiable, but I was able to perform a curl call from host1 to inet with nginx running there on docker.
#### Do you have any concerns with this PR?
arp table on SB host is not getting the mac of the remote host so there could still be issues to be addressed in ticket #301 therefore currently the necessary arp cache entries are getting manually added but the P4 paths are still being learned only in the lab_trial scenario.
#### How can the reviewer verify this PR?
Check CI
Can also try pinging from host1 or host2 to inet in your own EC2 environment after the tests have completed.
If you are really adventurous, you can fire up nginx on inet (docker installed not running) and see if you can connect from host1 or host2; however, if that does not work, I will be addressing those issues next.
#### Any background context you want to provide?
A step towards TCP support on Tofino
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? updated the existing ones
