### PR TITLE
Created web service to set Telemetry Report sample rate

### DIFF
--- a/playbooks/scenarios/aggregate/data-drop.yml
+++ b/playbooks/scenarios/aggregate/data-drop.yml
@@ -28,8 +28,8 @@
     send_port: 4321
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: aggregate-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"

--- a/playbooks/scenarios/aggregate/data-forward.yml
+++ b/playbooks/scenarios/aggregate/data-forward.yml
@@ -27,8 +27,8 @@
     rec_host: "{{ remote_rec_host  }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: aggregate-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
@@ -52,8 +52,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: aggregate-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     # For sending INT packets on the #1 of 3 send/receive iteration
     sr_data_inspection_int:

--- a/playbooks/scenarios/aggregate/data-inspection.yml
+++ b/playbooks/scenarios/aggregate/data-inspection.yml
@@ -25,8 +25,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: aggregate-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"

--- a/playbooks/scenarios/core/data-forward.yml
+++ b/playbooks/scenarios/core/data-forward.yml
@@ -26,8 +26,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: core-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     data_forwards:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
@@ -51,8 +51,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: core-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     sr_data_inspection_int:
       - switch_id: 1002

--- a/playbooks/scenarios/core/data-inspection.yml
+++ b/playbooks/scenarios/core/data-inspection.yml
@@ -26,8 +26,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts.host2 }}"
-    sender_intf_name: core-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
@@ -64,8 +64,8 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: core-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"

--- a/playbooks/scenarios/lab_trial/all-data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/all-data-inspection.yml
@@ -25,6 +25,7 @@
     scenario_send_ip_version: 4
     arp_discovery: True
     ae_state: stopped
+    sample_rate: 1
 
 # Data Inspection scenarios for UDP and IPv6
 - import_playbook: data-inspection.yml
@@ -33,6 +34,7 @@
     scenario_send_ip_version: 6
     arp_discovery: True
     ae_state: stopped
+    sample_rate: 1
 
 # Data Inspection scenarios for TCP and IPv4
 - import_playbook: data-inspection.yml
@@ -41,6 +43,7 @@
     scenario_send_ip_version: 4
     arp_discovery: True
     ae_state: stopped
+    sample_rate: 1
 
 # Data Inspection scenarios for TCP and IPv6
 - import_playbook: data-inspection.yml
@@ -49,3 +52,4 @@
     scenario_send_ip_version: 6
     arp_discovery: True
     ae_state: stopped
+    sample_rate: 1

--- a/playbooks/scenarios/lab_trial/all-pkt-flood.yml
+++ b/playbooks/scenarios/lab_trial/all-pkt-flood.yml
@@ -15,6 +15,8 @@
 ---
 # Refresh lab_trial environment config
 - import_playbook: restart.yml
+  vars:
+    ae_state: restarted
 
 # Data Inspection scenarios for UDP and IPv4
 - import_playbook: data-inspection.yml
@@ -27,6 +29,8 @@
     di_send_loops: 2
     di_send_loop_delay: 10
     arp_discovery: True
+    sample_rate: 0
+    ae_state: restarted
 
 # Data Inspection scenarios for UDP and IPv6 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -39,6 +43,8 @@
     di_send_loops: 2
     di_send_loop_delay: 10
     arp_discovery: True
+    sample_rate: 0
+    ae_state: restarted
 
 # Data Inspection scenarios for TCP and IPv4 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -51,6 +57,8 @@
     di_send_loops: 2
     di_send_loop_delay: 10
     arp_discovery: True
+    sample_rate: 0
+    ae_state: restarted
 
 # Data Inspection scenarios for TCP and IPv6 with AE for testing dropping packets
 - import_playbook: data-inspection.yml
@@ -63,3 +71,5 @@
     di_send_loops: 2
     di_send_loop_delay: 10
     arp_discovery: True
+    sample_rate: 0
+    ae_state: restarted

--- a/playbooks/scenarios/lab_trial/data-drop.yml
+++ b/playbooks/scenarios/lab_trial/data-drop.yml
@@ -28,8 +28,8 @@
     send_port: 4321
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver.mac }}"
     attack:
       url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"

--- a/playbooks/scenarios/lab_trial/data-forward.yml
+++ b/playbooks/scenarios/lab_trial/data-forward.yml
@@ -25,6 +25,6 @@
     rec_host: inet
     sender: "{{ topo_dict.hosts[send_host] }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver.mac }}"

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -31,6 +31,7 @@
     rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     sr1_rec_int_hops: 0
+    count_div: 1
 
 # Basic Data Inspection scenario - receiving packets on core-eth3 (INT packets)
 - import_playbook: data_inspection_basic.yml
@@ -50,3 +51,11 @@
     rec_intf_name: core-tun1
     dst_mac: "{{ receiver['mac'] }}"
     sr1_rec_int_hops: 2
+    count_div: 2
+    ws_calls:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/telemRptSample"
+        body:
+          sample: 1
+          switch_mac: "{{ switch.mac }}"
+          device_mac: "{{ sender.mac }}"
+        ok_status: 201

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -27,11 +27,16 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     sr1_rec_int_hops: 0
-    count_div: 1
+    expected_rate: 0
+    ws_calls:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/telemRptSample"
+        body:
+          sample: "{{ sample_rate }}"
+        ok_status: 201
 
 # Basic Data Inspection scenario - receiving packets on core-eth3 (INT packets)
 - import_playbook: data_inspection_basic.yml
@@ -47,15 +52,13 @@
     rec_host: "{{ remote_rec_host }}"
     sender: "{{ topo_dict.hosts[remote_send_host] }}"
     receiver: "{{ topo_dict.hosts.inet }}"
-    sender_intf_name: aggregate-tun1
-    rec_intf_name: core-tun1
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
     sr1_rec_int_hops: 2
-    count_div: 2
+    expected_rate: "{{ sample_rate }}"
     ws_calls:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/telemRptSample"
         body:
-          sample: 1
-          switch_mac: "{{ switch.mac }}"
-          device_mac: "{{ sender.mac }}"
+          sample: "{{ sample_rate }}"
         ok_status: 201

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -18,29 +18,23 @@
   gather_facts: no
   become: yes
   tasks:
-    - name: Restart tps-tofino-ae with state {{ ae_state | default('restarted') }}
+    - name: Restart tps-tofino-ae with state {{ ae_state | default('stopped') }}
       systemd:
         name: tps-tofino-ae
-        state: "{{ ae_state | default('restarted') }}"
+        state: "{{ ae_state | default('stopped') }}"
 
 # Call POST on all WS calls
 - hosts: controller
   gather_facts: no
   tasks:
-    - block:
-        - name: Web service calls to make
-          debug:
-            var: ws_calls
-
-        - name: POST WS calls
-          uri:
-            url: "{{ item.url }}"
-            method: POST
-            body_format: "{{ item.body_format | default('json') }}"
-            body: "{{ item.body }}"
-            status_code: "{{ item.ok_status | default('200') }}"
-          with_items: "{{ ws_calls }}"
-      when: ws_calls is defined
+    - name: Set sampling rate to 1 (one TRPT for 2 packets)
+      uri:
+        url: "http://{{ sdn_ip }}:{{ sdn_port }}/telemRptSample"
+        method: POST
+        body_format: json
+        body:
+          sample: 1
+        status_code: 201
 
 # Sending packets expect all to be received with configured INT hops sr1_rec_int_hops
 - import_playbook: ../test_cases/send_receive.yml
@@ -51,6 +45,8 @@
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 9) }}"
     send_src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 10) }}"
     send_packet_count: "{{ di_send_packet_count | default('%s' % 100 | random(seed=now|int + 11)) }}"
+    min_received_packet_count: "{{ send_packet_count | int / count_div - 1 }}"
+    max_received_packet_count: "{{ send_packet_count | int / count_div + 1 }}"
     inspection_data: "{{ sr1_data_inspection_int | default(None) }}"
     send_loops: "{{ di_send_loops | default(1) }}"
     send_loop_delay: "{{ di_send_loop_delay | default(5) }}"
@@ -61,17 +57,3 @@
         dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
         dst_port: "{{ send_port }}"
       ok_status: 201
-
-# Call DELETE on all WS calls
-- hosts: controller
-  gather_facts: no
-  tasks:
-    - name: DELETE WS calls
-      uri:
-        url: "{{ item.url }}"
-        method: DELETE
-        body_format: "{{ item.body_format | default('json') }}"
-        body: "{{ item.body }}"
-        status_code: "{{ item.ok_status | default('200') }}"
-      with_items: "{{ ws_calls }}"
-      when: ws_calls is defined

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -27,13 +27,13 @@
 - hosts: controller
   gather_facts: no
   tasks:
-    - name: Set sampling rate to 1 (one TRPT for 2 packets)
+    - name: Set sampling rate to {{ sample_rate }} (one TRPT for 2 packets)
       uri:
         url: "http://{{ sdn_ip }}:{{ sdn_port }}/telemRptSample"
         method: POST
         body_format: json
         body:
-          sample: 1
+          sample: "{{ sample_rate }}"
         status_code: 201
 
 # Sending packets expect all to be received with configured INT hops sr1_rec_int_hops
@@ -45,8 +45,8 @@
     send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 9) }}"
     send_src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 10) }}"
     send_packet_count: "{{ di_send_packet_count | default('%s' % 100 | random(seed=now|int + 11)) }}"
-    min_received_packet_count: "{{ send_packet_count | int / count_div - 1 }}"
-    max_received_packet_count: "{{ send_packet_count | int / count_div + 1 }}"
+    min_received_packet_count: "{{ (send_packet_count | int / (expected_rate + 1))|int - 1 }}"
+    max_received_packet_count: "{{ (send_packet_count | int / (expected_rate + 1))|int + 1 }}"
     inspection_data: "{{ sr1_data_inspection_int | default(None) }}"
     send_loops: "{{ di_send_loops | default(1) }}"
     send_loop_delay: "{{ di_send_loop_delay | default(5) }}"

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -167,8 +167,8 @@
 - hosts: "{{ rec_host }}"
   gather_facts: no
   vars:
-    min_packet_count: "{{ min_received_packet_count | default(send_packet_count) | int }}"
-    max_packet_count: "{{ max_received_packet_count | default(send_packet_count) | int }}"
+    min_packet_count: "{{ min_received_packet_count | default(send_packet_count|int - 1) }}"
+    max_packet_count: "{{ max_received_packet_count | default(send_packet_count|int)}}"
     hops: "{{ int_hops | default(0) }}"
     ip_ver: "{{ ip_version | default('4') }}"
     receiver_log_file: "{{ log_dir }}/{{ receiver_log_filename }}"

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -168,7 +168,7 @@
   gather_facts: no
   vars:
     min_packet_count: "{{ min_received_packet_count | default(send_packet_count|int - 1) }}"
-    max_packet_count: "{{ max_received_packet_count | default(send_packet_count|int)}}"
+    max_packet_count: "{{ max_received_packet_count | default(send_packet_count|int) }}"
     hops: "{{ int_hops | default(0) }}"
     ip_ver: "{{ ip_version | default('4') }}"
     receiver_log_file: "{{ log_dir }}/{{ receiver_log_filename }}"

--- a/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
@@ -18,6 +18,7 @@ hosts:
     name: host1
     id: 2
     ip: 192.168.1.2
+    intf_name: aggregate-tun1
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}
@@ -34,6 +35,7 @@ hosts:
     name: host2
     id: 3
     ip: 192.168.1.6
+    intf_name: aggregate-tun1
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}
@@ -50,6 +52,7 @@ hosts:
     name: inet
     id: 4
     ip: 192.168.1.10
+    intf_name: core-tun1
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}
@@ -66,6 +69,7 @@ hosts:
     name: ae
     id: 13
     ip: 192.168.1.14
+    intf_name: core-tun1
 {% if ae_user is defined or host_user is defined %}
     user: {{ ae_user | default(host_user) }}
 {% endif %}

--- a/playbooks/tofino/templates/topology_template-single_switch.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-single_switch.yaml.j2
@@ -3,6 +3,7 @@ hosts:
     name: host1
     id: 1
     ip: 192.168.1.2
+    intf_name: {{ p4_prog }}-tun1
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}
@@ -19,6 +20,7 @@ hosts:
     name: host2
     id: 2
     ip: 192.168.1.6
+    intf_name: {{ p4_prog }}-tun1
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}
@@ -35,6 +37,7 @@ hosts:
     name: clone
     id: 3
     ip: 192.168.1.10
+    intf_name: {{ p4_prog }}-tun1
 {% if host_user is defined %}
     user: {{ host_user }}
 {% endif %}

--- a/trans_sec/bfruntime_lib/aggregate_switch.py
+++ b/trans_sec/bfruntime_lib/aggregate_switch.py
@@ -87,7 +87,6 @@ class AggregateSwitch(BFRuntimeSwitch):
         while True:
             digest = None
             try:
-                logger.debug('Agg digest iter')
                 digest = self.interface.digest_get()
             except Exception as e:
                 if 'Digest list not received' not in str(e):

--- a/trans_sec/bfruntime_lib/core_switch.py
+++ b/trans_sec/bfruntime_lib/core_switch.py
@@ -51,6 +51,10 @@ telem_rpt_tbl = 'TpsCoreEgress.setup_telemetry_rpt_t'
 telem_rpt_tbl_key = 'hdr.udp_int.dst_port'
 telem_rpt_data = 'ae_ip'
 
+trpt_sample_tbl = 'TpsCoreIngress.mirror_sampler'
+trpt_sample_key = '$REGISTER_INDEX'
+trpt_rate_field = 'TpsCoreIngress.mirror_sampler.rate'
+
 
 class CoreSwitch(BFRuntimeSwitch):
     def __init__(self, sw_info, client_id=0, is_master=True):
@@ -221,3 +225,17 @@ class CoreSwitch(BFRuntimeSwitch):
                 pass
             else:
                 raise e
+
+    def set_trpt_sampling_value(self, sample_size):
+        logger.info(
+            'Setting up telemetry report sample size core device [%s] to [%s]',
+            self.device_id, sample_size)
+
+        sample_tbl = self.get_table(trpt_sample_tbl)
+        sample_tbl.entry_add(
+            self.target,
+            [sample_tbl.make_key([KeyTuple(trpt_sample_key, 0)])],
+            [sample_tbl.make_data([
+                DataTuple(trpt_rate_field, sample_size),
+            ])]
+        )

--- a/trans_sec/controller/core_controller.py
+++ b/trans_sec/controller/core_controller.py
@@ -68,16 +68,14 @@ class CoreController(AbstractController):
             if switch.mac == kwargs['switch_mac']:
                 switch.setup_telemetry_rpt(kwargs['ae_ip'], kwargs['port'])
 
+    def set_trpt_sampling_value(self, sample_size):
+        for switch in self.switches:
+            switch.set_trpt_sampling_value(sample_size)
+
     def remove_telem_rpt(self, **kwargs):
         for switch in self.switches:
             if switch.mac == kwargs['switch_mac']:
                 switch.remove_telemetry_rpt(kwargs['ae_ip'], kwargs['port'])
-
-    def add_attacker(self, attack, host):
-        pass
-
-    def remove_attacker(self, attack, host):
-        pass
 
     def add_attacker(self, attack, host):
         pass

--- a/trans_sec/controller/ddos_sdn_controller.py
+++ b/trans_sec/controller/ddos_sdn_controller.py
@@ -81,7 +81,8 @@ class DdosSdnController:
                     ae_ip = ipaddress.ip_address(ae_ip_str)
                     logger.info('AE IP Address - [%s]', ae_ip)
                 except ValueError as e:
-                    logger.warning('Cannot create drop report, ae_ip invalid')
+                    logger.warning(
+                        'Cannot create drop report, ae_ip invalid - [%s]', e)
                     return
         if ae_ip:
             self.__create_drop_report(ae_ip)
@@ -272,12 +273,31 @@ class DdosSdnController:
         :param request: dict of the request
         """
         core_controller = self.get_core_controller()
-        logger.info('Adding telemetry report config to core')
+        logger.info('Activating telemetry report for core')
         if core_controller:
             try:
                 core_controller.setup_telem_rpt(**request)
             except Exception as e:
-                logger.error('Error adding attacker with error - [%s])', e)
+                logger.error(
+                    'Error setting up telemetry report with error - [%s])', e)
+        else:
+            logger.warning('Aggregate controller cannot add attack')
+
+    def set_trpt_sampling_value(self, request):
+        """
+        Adds a device to mitigate an attack
+        :param request: dict of the request
+        """
+        core_controller = self.get_core_controller()
+        logger.info('Setting telemetry report sampling value to core')
+        sample_size = request.get('sample')
+        if core_controller and sample_size:
+            try:
+                logger.info('Adding sample_size - [%s]', sample_size)
+                core_controller.set_trpt_sampling_value(int(sample_size))
+            except Exception as e:
+                logger.error(
+                    'Error setting TRPT sample value with error - [%s])', e)
         else:
             logger.warning('Aggregate controller cannot add attack')
 
@@ -287,7 +307,7 @@ class DdosSdnController:
         :param request: dict of the request
         """
         core_controller = self.get_core_controller()
-        logger.info('Adding telemetry report config to core')
+        logger.info('Deactivating telemetry report config to core')
         if core_controller:
             try:
                 core_controller.setup_telem_rpt(**request)

--- a/trans_sec/controller/http_server_flask.py
+++ b/trans_sec/controller/http_server_flask.py
@@ -50,6 +50,9 @@ class SDNControllerServer:
         self.api.add_resource(
             TelemetryReport, '/setupTelemRpt',
             resource_class_kwargs={'sdn_controller': self.sdn_controller})
+        self.api.add_resource(
+            TelemetryReportSampling, '/telemRptSample',
+            resource_class_kwargs={'sdn_controller': self.sdn_controller})
         self.api.add_resource(Shutdown, '/shutdown')
 
     def stop(self):
@@ -260,6 +263,26 @@ class TelemetryReport(Resource):
 
         logger.info('Attack args - [%s]', args)
         self.sdn_controller.remove_agg_attacker(args)
+        return json.dumps({"success": True}), 201
+
+
+class TelemetryReportSampling(Resource):
+    """
+    Class for exposing web service to change the Telemetry Report sampling
+    value. i.e. When "count" == 0, every INT packet will generate a Telem rpt
+                when "count" == 1, every other; 2 - every third etc
+    """
+    def __init__(self, **kwargs):
+        self.sdn_controller = kwargs['sdn_controller']
+        self.parser = reqparse.RequestParser()
+        self.parser.add_argument('sample', type=int, default=0)
+
+    def post(self):
+        logger.info('Setting Telemetry report sampling value')
+        args = self.parser.parse_args()
+
+        logger.info('Attack args - [%s]', args)
+        self.sdn_controller.set_trpt_sampling_value(args)
         return json.dumps({"success": True}), 201
 
 


### PR DESCRIPTION
#### What does this PR do?
Fixes #328 
Allows for setting the Tlemetry Report sample rate from the SDN web service. This PR includes tests that exercise the web service and validates a sample rate of '1' (1 packet for every 2) on the 'ae' machine.

Also added "intf_name" field to each host in the topology to be used by the automated tests.

#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
Run the lab_trial automation scripts
#### Any background context you want to provide?
After adding in sample rate support for Telemetry Reports, we needed some tests and required the web service on the SDN Controller. This should be useful during the lab trial too.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? eventually
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? yes, I added a call to the web service and ensured only 1/2 of the send packets are arriving.
