### PR TITLE
Configure switch default port

### DIFF
--- a/p4/include/tps_consts.p4
+++ b/p4/include/tps_consts.p4
@@ -100,6 +100,7 @@ const PortId_t DROP_PORT = 511;
 
 /* Digest constants */
 const bit<3> DIGEST_TYPE_ARP = 0x1;
+const bit<16> ARP_REQUEST = 0x1;
 
 /* Constants for determining BMV2 Packet instance_types */
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_NORMAL        = 0;
@@ -118,3 +119,5 @@ const bit<32> E2E_CLONE_SESSION_ID = 11;
 #define IS_RESUBMITTED(std_meta) (std_meta.instance_type == BMV2_V1MODEL_INSTANCE_TYPE_RESUBMIT)
 #define IS_I2E_CLONE(std_meta) (std_meta.instance_type == BMV2_V1MODEL_INSTANCE_TYPE_INGRESS_CLONE)
 #define IS_E2E_CLONE(std_meta) (std_meta.instance_type == BMV2_V1MODEL_INSTANCE_TYPE_EGRESS_CLONE)
+
+const bit<3> TNA_DROP_CTL = 0x1;

--- a/playbooks/scenarios/aggregate/data-drop.yml
+++ b/playbooks/scenarios/aggregate/data-drop.yml
@@ -21,13 +21,11 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
-    remote_send_host: host1
-    remote_rec_host: host2
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     send_port: 4321
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -37,7 +35,7 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201
     attack:
       url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"

--- a/playbooks/scenarios/aggregate/data-forward.yml
+++ b/playbooks/scenarios/aggregate/data-forward.yml
@@ -21,12 +21,10 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
-    remote_send_host: host1
-    remote_rec_host: host2
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host  }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -36,7 +34,7 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201
 
 # Basic Data Forward scenario for INT UDP Packets without a data-inspection table entry so the original simply passes through
@@ -46,12 +44,10 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
-    remote_send_host: host1
-    remote_rec_host: host2
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -66,5 +62,5 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201

--- a/playbooks/scenarios/aggregate/data-inspection.yml
+++ b/playbooks/scenarios/aggregate/data-inspection.yml
@@ -19,12 +19,10 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
-    remote_send_host: host1
-    remote_rec_host: host2
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -34,7 +32,7 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201
     data_inspections:
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"

--- a/playbooks/scenarios/core/data-forward.yml
+++ b/playbooks/scenarios/core/data-forward.yml
@@ -20,12 +20,10 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.core }}"
-    remote_send_host: host1
-    remote_rec_host: host2
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -35,7 +33,7 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201
 
 # Basic Data Forward scenario for INT packets to egress port
@@ -45,12 +43,10 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.core }}"
-    remote_send_host: host1
-    remote_rec_host: host2
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -65,5 +61,5 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201

--- a/playbooks/scenarios/core/data-inspection.yml
+++ b/playbooks/scenarios/core/data-inspection.yml
@@ -20,12 +20,10 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.core }}"
-    remote_send_host: host1
-    remote_rec_host: clone
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts.host2 }}"
+    send_host: host1
+    rec_host: clone
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -35,7 +33,7 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/setupTelemRpt"
         body:
@@ -58,12 +56,10 @@
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.core }}"
-    remote_send_host: host1
-    remote_rec_host: host2
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -73,7 +69,7 @@
           device_id: "{{ switch.id }}"
           switch_mac: "{{ switch.mac }}"
           dst_mac: "{{ receiver.mac }}"
-          output_port: 2
+          output_port: "{{ switch.tunnels[2].switch_port }}"
         ok_status: 201
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/setupTelemRpt"
         body:

--- a/playbooks/scenarios/lab_trial/data-drop.yml
+++ b/playbooks/scenarios/lab_trial/data-drop.yml
@@ -21,13 +21,11 @@
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
     switch2: "{{ topo_dict.switches.core }}"
-    remote_send_host: host1
-    remote_rec_host: inet
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
+    send_host: host1
+    rec_host: inet
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     send_port: 4321
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver.mac }}"

--- a/playbooks/scenarios/lab_trial/data-inspection.yml
+++ b/playbooks/scenarios/lab_trial/data-inspection.yml
@@ -13,7 +13,7 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-# Basic Data Inspection scenario - receiving packets on core-eth2 (non-INT packets)
+# Basic Data Inspection scenario - receiving packets on inet host
 - import_playbook: data_inspection_basic.yml
   vars:
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
@@ -21,12 +21,10 @@
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
     switch2: "{{ topo_dict.switches.core }}"
-    remote_send_host: host1
-    remote_rec_host: inet
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts[remote_rec_host] }}"
+    send_host: host1
+    rec_host: inet
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"
@@ -38,7 +36,7 @@
           sample: "{{ sample_rate }}"
         ok_status: 201
 
-# Basic Data Inspection scenario - receiving packets on core-eth3 (INT packets)
+# Basic Data Inspection scenario - receiving packets on AE/clone port
 - import_playbook: data_inspection_basic.yml
   vars:
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
@@ -46,12 +44,10 @@
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
     switch: "{{ topo_dict.switches.aggregate }}"
     switch2: "{{ topo_dict.switches.core }}"
-    remote_send_host: host1
-    remote_rec_host: ae
-    send_host: "{{ remote_send_host }}"
-    rec_host: "{{ remote_rec_host }}"
-    sender: "{{ topo_dict.hosts[remote_send_host] }}"
-    receiver: "{{ topo_dict.hosts.inet }}"
+    send_host: host1
+    rec_host: ae
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
     sender_intf_name: "{{ sender.intf_name }}"
     rec_intf_name: "{{ receiver.intf_name }}"
     dst_mac: "{{ receiver['mac'] }}"

--- a/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
@@ -103,11 +103,12 @@ switches:
     ipv6_term_host: inet
     tunnels:
       - host: core
-        switch_port: 1
+        switch_port: 128
+        type: default
       - host: host1
-        switch_port: 2
+        switch_port: 136
       - host: host2
-        switch_port: 3
+        switch_port: 144
   core:
     name: core
     id: 0
@@ -121,7 +122,7 @@ switches:
 {% endif %}
     tun1_ip: {{ core_tun1_ip }}
     tun1_mac: {{ core_tun1_mac }}
-    clone_egress: 3
+    clone_egress: 144
     telemetry_rpt:
       type: host
       name: ae
@@ -129,11 +130,12 @@ switches:
     arch: {{ p4_arch }}
     tunnels:
       - host: aggregate
-        switch_port:  1
+        switch_port:  128
+        type: default
       - host: inet
-        switch_port:  2
+        switch_port:  136
       - host: ae
-        switch_port:  3
+        switch_port:  144
     mac: 00:00:00:03:05:00
     grpc: {{ core_ip }}:{{ grpc_port }}
     ipv6_term_host: inet

--- a/playbooks/tofino/templates/topology_template-single_switch.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-single_switch.yaml.j2
@@ -58,7 +58,7 @@ switches:
     runtime_p4info: {{ remote_scripts_dir }}/p4/{{ p4_prog }}.tofino/p4info.pb.txt
     tofino_bin: {{ remote_scripts_dir }}/p4/{{ p4_prog }}.tofino/pipe/tofino.bin
     ctx_json: {{ remote_scripts_dir }}/p4/{{ p4_prog }}.tofino/pipe/context.json
-    clone_egress: 3
+    clone_egress: 152
     ip: {{ switch_ip }}
 {% if switch_user is defined %}
     user: {{ switch_user }}
@@ -71,13 +71,14 @@ switches:
     arch: {{ p4_arch }}
     tunnels:
       - host: dummy
-        switch_port: 1
+        switch_port: 128
+        type: default
       - host: host1
-        switch_port: 4
+        switch_port: 136
       - host: host2
-        switch_port: 2
+        switch_port: 144
       - host: clone
-        switch_port: 3
+        switch_port: 152
     telemetry_rpt:
       type: host
       name: clone

--- a/trans_sec/bfruntime_lib/aggregate_switch.py
+++ b/trans_sec/bfruntime_lib/aggregate_switch.py
@@ -42,6 +42,10 @@ data_inspection_action = 'TpsAggEgress.data_inspect_packet'
 data_inspection_action_val_1 = 'device'
 data_inspection_action_val_2 = 'switch_id'
 
+dflt_port_tbl = 'TpsAggIngress.default_port_t'
+dflt_port_action = 'TpsAggIngress.get_default_port'
+dflt_port_action_val = 'port'
+
 data_fwd_tbl = 'TpsAggIngress.data_forward_t'
 data_fwd_tbl_key = 'hdr.ethernet.dst_mac'
 data_fwd_action = 'TpsAggIngress.data_forward'
@@ -152,6 +156,14 @@ class AggregateSwitch(BFRuntimeSwitch):
             dev_id, dev_mac, data_inspection_tbl)
         self.delete_table_entry(data_inspection_tbl,
                                 [KeyTuple(data_inspection_tbl_key, dev_mac)])
+
+    def update_default_port(self, dflt_port):
+        logger.info('Setting default port to - [%s]', dflt_port)
+        dflt_tbl = self.get_table(dflt_port_tbl)
+        data = dflt_tbl.make_data(
+            [DataTuple(dflt_port_action_val, int(dflt_port))],
+            dflt_port_action)
+        dflt_tbl.default_entry_set(self.target, data)
 
     def add_data_forward(self, dst_mac, ingress_port):
         logger.info(

--- a/trans_sec/bfruntime_lib/core_switch.py
+++ b/trans_sec/bfruntime_lib/core_switch.py
@@ -42,6 +42,10 @@ add_switch_id_tbl_key = 'hdr.udp_int.dst_port'
 add_switch_id_action = 'TpsCoreEgress.add_switch_id'
 add_switch_id_action_val = 'switch_id'
 
+dflt_port_tbl = 'TpsCoreIngress.default_port_t'
+dflt_port_action = 'TpsCoreIngress.get_default_port'
+dflt_port_action_val = 'port'
+
 data_fwd_tbl = 'TpsCoreIngress.data_forward_t'
 data_fwd_tbl_key = 'hdr.ethernet.dst_mac'
 data_fwd_action = 'TpsCoreIngress.data_forward'
@@ -115,6 +119,14 @@ class CoreSwitch(BFRuntimeSwitch):
     def __set_table_field_annotations(self):
         df_table = self.get_table(data_fwd_tbl)
         df_table.info.key_field_annotation_add(data_fwd_tbl_key, "mac")
+
+    def update_default_port(self, dflt_port):
+        logger.info('Setting default port to - [%s]', dflt_port)
+        dflt_tbl = self.get_table(dflt_port_tbl)
+        data = dflt_tbl.make_data(
+            [DataTuple(dflt_port_action_val, int(dflt_port))],
+            dflt_port_action)
+        dflt_tbl.default_entry_set(self.target, data)
 
     def add_data_forward(self, dst_mac, ingress_port):
         logger.info(


### PR DESCRIPTION
#### What does this PR do?
Fixes #314 
Adds the ability to configure the default output port which by default is bit<3>1.
As the ports on the Wedge Core switch do not map nicely to 1, 2, 3, 4 as our automated tests had been doing, I have changed all of the port values to the same that we will be using on the Wedge Core.
Tests needed to be addressed as well.
Port values will be encoded in the switch.tunnels portion of the topology as well as the "clone_egress" section.
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
Ensure CI executes properly. One then can check out the data_forward_t port values to ensure they are no longer 1, 2, 3, and/or 4.
#### Any background context you want to provide?
Issue found while deploying and iperf3 testing our P4 code on Wedge Core #1
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? not at this time
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? Fixed the existing ones to leverage the correct port values when making explicit inserts to data_forward_t.
