### PR TITLE
Ensure L2 routing for IPv6 hosts

### DIFF
--- a/automation/p4/tofino/variables.tf
+++ b/automation/p4/tofino/variables.tf
@@ -35,7 +35,7 @@ variable "tofino" {
     bfrt_ami = "ami-01a5ff54de23b6739"
   }
 }
-variable "hcp_ami" {default ="ami-0bc9ab59c9cd89a82"}
+variable "hcp_ami" {default ="ami-03599ec09c2799e84"}
 
 variable "switch_instance_type" {default = "t2.2xlarge"}
 variable "ae_instance_type" {default = "t2.large"}

--- a/playbooks/ae/setup_ae_elk.yml
+++ b/playbooks/ae/setup_ae_elk.yml
@@ -13,6 +13,8 @@
 
 - hosts: ae
   gather_facts: no
+  vars:
+    - CENTOS_HOME: "/home/centos"
   tasks:
     - name: "Start Elasticsearch service"
       become: yes
@@ -110,7 +112,7 @@
         remote_src: yes
         force: yes
 
-    - name: Replace SDN Webhook ID in monitor definition file
+    - name: Replace SDN Webhook ID in UDP monitor definition file
       become: yes
       tags: monitorUpdate
       lineinfile:

--- a/playbooks/ae/templates/opendistro_elasticsearch.sh
+++ b/playbooks/ae/templates/opendistro_elasticsearch.sh
@@ -52,11 +52,11 @@ path.logs: /var/log/elasticsearch
 #
 # Set the bind address to a specific IP (IPv4 or IPv6):
 #
-network.host: 0.0.0.0
+#network.host: 0.0.0.0
 #
 # Set a custom port for HTTP:
 #
-http.port: 9200
+#http.port: 9200
 #
 # For more information, consult the network module documentation.
 #
@@ -65,7 +65,7 @@ http.port: 9200
 # Pass an initial list of hosts to perform discovery when this node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
-#discovery.seed_hosts: ["host1", "host2"]
+#discovery.seed_hosts: ["127.0.0.1"]
 #
 # Bootstrap the cluster using an initial set of master-eligible nodes:
 #

--- a/playbooks/ae/templates/tcp_data_mapping.json
+++ b/playbooks/ae/templates/tcp_data_mapping.json
@@ -1,0 +1,280 @@
+{
+    "index_patterns" : [
+      "packets-*"
+    ],
+    "settings" : {
+      "index" : {
+        "number_of_replicas" : "0",
+        "default_pipeline" : "ts_tcp_parsing",
+        "max_script_fields" : "200"
+      }
+    },
+    "mappings" : {
+      "dynamic" : "false",
+      "properties" : {
+        "layers" : {
+          "properties" : {
+            "data_raw" : {
+              "type" : "keyword"
+            },
+            "data" : {
+              "properties" : {
+                "data_data_data_raw" : {
+                  "type" : "keyword"
+                },
+                "data_data_len" : {
+                  "type" : "keyword"
+                },
+                "data_data_data" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
+        },
+        "timestamp" : {
+          "type" : "date"
+        },
+        "ts" : {
+          "properties" : {
+            "INTMetadataSourceMetadataReserved" : {
+              "type" : "keyword"
+            },
+
+            "UDPIntShimHeaderType" : {
+              "type" : "keyword"
+            },
+            "telemetryReportLength" : {
+              "type" : "keyword"
+            },
+            "data" : {
+              "type" : "keyword"
+            },
+            "ethernetHeaderDestMac" : {
+              "type" : "keyword"
+            },
+            "telemetryRsvd" : {
+              "type" : "keyword"
+            },
+            "UDGSrcPort" : {
+              "type" : "keyword"
+            },
+            "INTMetadataSourceMetadataSwitchId" : {
+              "type" : "keyword"
+            },
+            "ethernetHeaderSrcMac" : {
+              "type" : "keyword"
+            },
+            "UDPIntShimHeaderNextProto" : {
+              "type" : "keyword"
+            },
+            "isIpv4" : {
+              "type" : "keyword"
+            },
+            "nextProto": {
+               "type" : "keyword"
+            },
+            "isTCP" : {
+              "type" : "keyword"
+            },
+            "isUDP" : {
+              "type" : "keyword"
+            },
+            "TCPData" : {
+              "type" : "keyword"
+            },
+            "TCPSrcPort" : {
+              "type" : "keyword"
+            },
+            "TCPDestPort" : {
+              "type" : "keyword"
+            },
+            "TCPIntShimHeaderNextProto" : {
+              "type" : "keyword"
+            },
+
+            "UDPIntMetaDataHeaderVersion" : {
+              "type" : "keyword"
+            },
+            "IPvNextHdrProto" : {
+              "type" : "keyword"
+            },
+            "telemetryReportVersion" : {
+              "type" : "keyword"
+            },
+            "isIpv6" : {
+              "type" : "keyword"
+            },
+            "INTMetadataSourceMetadataOriginatingMac" : {
+              "type" : "keyword"
+            },
+
+            "UDPIntMetaDataHeaderInstructionBitmap" : {
+              "type" : "keyword"
+            },
+            "INTMetadataSourceMetadata" : {
+              "type" : "keyword"
+            },
+            "IPvSrcAddr" : {
+              "type" : "keyword"
+            },
+            "tsRawDataSize" : {
+              "type" : "keyword"
+            },
+            "UDGPData" : {
+              "type" : "keyword"
+            },
+            "UDGChecksum" : {
+              "type" : "keyword"
+            },
+            "INTMetadataHeaderData" : {
+              "type" : "keyword"
+            },
+            "IPvDestAddr" : {
+              "type" : "keyword"
+            },
+            "telemetryInType" : {
+              "type" : "keyword"
+            },
+            "telemetryReport" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderDSFlags" : {
+              "type" : "keyword"
+            },
+            "telemetryDsMdStatus" : {
+              "type" : "keyword"
+            },
+            "InBandNetworkTelemetryData" : {
+              "type" : "keyword"
+            },
+            "UDPIntShimHeaderRes2" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderDSInstruction" : {
+              "type" : "keyword"
+            },
+            "UDPIntShimHeaderRes1" : {
+              "type" : "keyword"
+            },
+            "UDP2Data" : {
+              "type" : "keyword"
+            },
+            "telemetryHwdId" : {
+              "type" : "keyword"
+            },
+
+            "telemetryVarOpt" : {
+              "type" : "keyword"
+            },
+            "IPvData" : {
+              "type" : "keyword"
+            },
+            "ethernetHeaderEtherType" : {
+              "type" : "keyword"
+            },
+            "INTMetadataStackData" : {
+              "type" : "keyword"
+            },
+            "IPvFlow" : {
+              "type" : "keyword"
+            },
+            "UDPIntShimHeaderData" : {
+              "type" : "keyword"
+            },
+            "INTMetadataStackSwitchID" : {
+              "type" : "keyword"
+            },
+            "IPVersion" : {
+              "type" : "keyword"
+            },
+            "IPvPayloadLength" : {
+              "type" : "keyword"
+            },
+            "UDPIntShimHeaderLength" : {
+              "type" : "keyword"
+            },
+            "UDPIntShimHeaderNPT" : {
+              "type" : "keyword"
+            },
+            "UDGLength" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderM" : {
+              "type" : "keyword"
+            },
+
+            "telemetryD" : {
+              "type" : "keyword"
+            },
+            "rawData" : {
+              "type" : "keyword"
+            },
+            "telemetryF" : {
+              "type" : "keyword"
+            },
+            "telemetryReportType" : {
+              "type" : "keyword"
+            },
+            "telemetryI" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderPerhopMetadataLength" : {
+              "type" : "keyword"
+            },
+            "telemetryQ" : {
+              "type" : "keyword"
+            },
+            "telemetryDomainSpecificID" : {
+              "type" : "keyword"
+            },
+            "udpLayersSize" : {
+              "type" : "keyword"
+            },
+            "UDGDstPort" : {
+              "type" : "keyword"
+            },
+            "IPvNextHopLimit" : {
+              "type" : "keyword"
+            },
+            "telemetryDsMdBits" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderDomainSpecificID" : {
+              "type" : "keyword"
+            },
+            "telemetryRepMdBits" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderRemainingHopCnt" : {
+              "type" : "keyword"
+            },
+            "telemetrySequenceNumber" : {
+              "type" : "keyword"
+            },
+            "telemetryMDLength" : {
+              "type" : "keyword"
+            },
+            "IPvClass" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderD" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderE" : {
+              "type" : "keyword"
+            },
+            "telemetryNodeId" : {
+              "type" : "keyword"
+            },
+            "dataII" : {
+              "type" : "keyword"
+            },
+            "UDPIntMetaDataHeaderRes" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      }
+    }
+}

--- a/playbooks/ae/templates/tcp_data_parsing.json
+++ b/playbooks/ae/templates/tcp_data_parsing.json
@@ -1,0 +1,1318 @@
+{
+    "description" : "Transparent Security TCP v4 & v6 data parsing pipeline",
+    "processors" : [
+      {
+        "set" : {
+          "field" : "ts.rawData",
+          "value" : "{{layers.data.data_data_data}}"
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : "ctx.ts.telemetryReport =ctx.ts.rawData.substring(0, 48).replace(':','')",
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String hardwareIdStr = ctx.layers.data.data_data_data.replace(':','').substring(1, 3);
+               BigInteger hwdIdBigInt = new BigInteger(hardwareIdStr, 16);
+               BigInteger bitwiseAnd = new BigInteger('FC', 16);
+               BigInteger extractedHardwareId = hwdIdBigInt.and(bitwiseAnd);
+               String hwdIdStr =  extractedHardwareId.toString(16);
+               ctx.ts.telemetryHwdId = hwdIdStr;
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String sequenceNumberPartStrI = tsRawData.substring(2, 3);
+               String sequenceNumberPartStrII = tsRawData.substring(3, 8);
+               String sequenceNumberPartStr = tsRawData.substring(2, 8);
+               BigInteger sequenceNumberBigInt = new BigInteger(sequenceNumberPartStr, 16);
+               BigInteger bitwiseAnd = new BigInteger('7FFFFFF', 16);
+               BigInteger updatedSequenceNumber = sequenceNumberBigInt.and(bitwiseAnd);
+               // String sequenceNumberHexStr =  updatedSequenceNumber.toString(16);
+               ctx.ts.telemetrySequenceNumber = updatedSequenceNumber.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String nodeIdStr = tsRawData.substring(8, 16);
+               BigInteger nodeIdBigInt = new BigInteger(nodeIdStr, 16);
+               ctx.ts.telemetryNodeId =nodeIdBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String repTypeStr = tsRawData.substring(16, 17);
+               BigInteger repTypeBigInt = new BigInteger(repTypeStr, 16);
+               ctx.ts.telemetryReportType =repTypeBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+                String inTypeStr = tsRawData.substring(17, 18);
+               BigInteger inTypeBigInt = new BigInteger(inTypeStr, 16);
+               ctx.ts.telemetryInType = inTypeBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String reportLengthStr = tsRawData.substring(18, 20);
+               BigInteger reportLengthBigInt = new BigInteger(reportLengthStr, 16);
+               ctx.ts.telemetryReportLength = reportLengthBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String mdLengthStr = tsRawData.substring(20, 22);
+               BigInteger mdLengthBigInt = new BigInteger(mdLengthStr, 16);
+               ctx.ts.telemetryMDLength = mdLengthBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String dStr = tsRawData.substring(22, 23);
+               BigInteger dBigInt = new BigInteger(dStr, 16);
+               BigInteger bitwiseAnd = new BigInteger('8', 16);
+               BigInteger dRes = dBigInt.and(bitwiseAnd);
+               ctx.ts.telemetryD = dRes.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String qStr = tsRawData.substring(22, 23);
+               BigInteger qBigInt = new BigInteger(qStr, 16);
+               BigInteger bitwiseAnd = new BigInteger('4', 16);
+               BigInteger qRes = qBigInt.and(bitwiseAnd);
+               ctx.ts.telemetryQ = qRes.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String fStr = tsRawData.substring(22, 23);
+               BigInteger fBigInt = new BigInteger(fStr, 16);
+               BigInteger bitwiseAnd = new BigInteger('2', 16);
+               BigInteger fRes = fBigInt.and(bitwiseAnd);
+               ctx.ts.telemetryF = fRes.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String IStr = tsRawData.substring(22, 23);
+               BigInteger IBigInt = new BigInteger(IStr, 16);
+               BigInteger bitwiseAnd = new BigInteger('1', 16);
+               BigInteger IRes = IBigInt.and(bitwiseAnd);
+               ctx.ts.telemetryI = IRes.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String rsvdStr = tsRawData.substring(23, 24);
+               BigInteger rsvdBigInt = new BigInteger(rsvdStr, 16);
+               ctx.ts.telemetryRsvd = rsvdBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+                String repMdBitsStr = tsRawData.substring(24, 28);
+               BigInteger repMdBitsBigInt = new BigInteger(repMdBitsStr, 16);
+               ctx.ts.telemetryRepMdBits = repMdBitsBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String domainSpecificIDStr = tsRawData.substring(28, 32);
+               BigInteger domainSpecificIDBigInt = new BigInteger(domainSpecificIDStr, 16);
+               ctx.ts.telemetryDomainSpecificID = domainSpecificIDBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String dsMdBitsStr = tsRawData.substring(32, 36);
+               BigInteger dsMdBitsStrBigInt = new BigInteger(dsMdBitsStr, 16);
+               ctx.ts.telemetryDsMdBits = dsMdBitsStrBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String dsMdStatusStr = tsRawData.substring(36, 40);
+               BigInteger dsMdStatusBigInt = new BigInteger(dsMdStatusStr, 16);
+               ctx.ts.telemetryDsMdStatus = dsMdStatusBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+               String varOptStr = tsRawData.substring(40, 48);
+               BigInteger varOptBigInt = new BigInteger(varOptStr, 16);
+               ctx.ts.telemetryVarOpt = varOptBigInt.intValue();
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+                String etherType = tsRawData.substring(72, 76);
+                String ipVersion = tsRawData.substring(76, 77);
+                if( etherType == '86dd' && ipVersion == '6')
+                {
+                  ctx.ts.isIPv6 = true;
+                } else
+                {
+                   ctx.ts.isIPv6 = false;
+                }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+                String etherType = tsRawData.substring(72, 76);
+                String ipVersion = tsRawData.substring(76, 77);
+                if( etherType == '0800' && ipVersion == '4')
+                {
+                  ctx.ts.isIPv4 = true;
+                } else
+                {
+                   ctx.ts.isIPv4 = false;
+                }
+        """,
+          "ignore_failure" : true
+        }
+      },
+       {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+                String etherType = tsRawData.substring(72, 76);
+                String ipVersion = tsRawData.substring(76, 77);
+               if( etherType == '0800' && ipVersion == '4')
+              {
+                 String nextProtoStr = tsRawData.substring(138, 140);
+                 BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+                ctx.ts.nextProto = nextProtoBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                   String nextProtoStr = tsRawData.substring(178, 180);
+                   BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+                  ctx.ts.nextProto = nextProtoBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+
+       {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+                String etherType = tsRawData.substring(72, 76);
+                String ipVersion = tsRawData.substring(76, 77);
+                String tcpNextProtoStr = '6';
+                int tcpNextProtoInt = Integer.parseInt(tcpNextProtoStr);
+
+                if( etherType == '0800' && ipVersion == '4')
+                {
+                  String nextProtoStr = tsRawData.substring(138, 140);
+                  BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+
+                  if( ctx.ts.nextProto == tcpNextProtoInt )
+                  {
+                    ctx.ts.isTCP = true;
+                  }else {
+                   ctx.ts.isTCP = false;
+                 }
+                }
+
+                if( etherType == '86dd' && ipVersion == '6')
+                {
+                  String nextProtoStr = tsRawData.substring(178, 180);
+                   BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+                   String UDPNextProtoStr = ctx.ts.UDPIntShimHeaderNextProto.toString();
+                    if( ctx.ts.nextProto == tcpNextProtoInt )
+                  {
+                    ctx.ts.isTCP = true;
+                  }else {
+                   ctx.ts.isTCP = false;
+                 }
+                }
+
+        """,
+          "ignore_failure" : true
+        }
+      },
+
+       {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+               String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+                String etherType = tsRawData.substring(72, 76);
+                String ipVersion = tsRawData.substring(76, 77);
+                String udpNextProtoStr = '17';
+                int udpNextProtoInt = Integer.parseInt(udpNextProtoStr);
+                if( etherType == '0800' && ipVersion == '4')
+                {
+                  String nextProtoStr = tsRawData.substring(138, 140);
+                   BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+                   String UDPNextProtoStr = ctx.ts.UDPIntShimHeaderNextProto.toString();
+                  if(ctx.ts.nextProto == udpNextProtoInt )
+                  {
+                    ctx.ts.isUDP = true;
+                  }else {
+                   ctx.ts.isUDP = false;
+                 }
+                }
+
+                if( etherType == '86dd' && ipVersion == '6')
+                {
+                  String nextProtoStr = tsRawData.substring(178, 180);
+                   BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+                   String UDPNextProtoStr = ctx.ts.UDPIntShimHeaderNextProto.toString();
+                    if(ctx.ts.nextProto == udpNextProtoInt )
+                  {
+                    ctx.ts.isUDP = true;
+                  }else {
+                   ctx.ts.isUDP = false;
+                 }
+                }
+
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               ctx.ts.data = tsRawData.substring(48, 252);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               ctx.ts.data = tsRawData.substring(48, 292);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+               ctx.ts.ethernetHeader = tsRawData.substring(48, 76);
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              ctx.ts.ethernetHeaderDestMac = tsRawData.substring(48, 60);
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              ctx.ts.ethernetHeaderSrcMac = tsRawData.substring(60, 72);
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+             ctx.ts.ethernetHeaderEtherType = tsRawData.substring(72, 76);
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               ctx.ts.IPvData = tsRawData.substring(76, 116);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               ctx.ts.IPvData = tsRawData.substring(76, 156);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               ctx.ts.IPVersion = tsRawData.substring(76, 77);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               ctx.ts.IPVersion = tsRawData.substring(76, 77);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               String IPv4SrcIPHexString = tsRawData.substring(100, 108);
+               String IPv4SrcIP = "";
+                for(int i = 0; i < IPv4SrcIPHexString.length(); i = i + 2) {
+                     IPv4SrcIP = IPv4SrcIP + Integer.valueOf(IPv4SrcIPHexString.substring(i, i+2), 16) + ".";
+                }
+                IPv4SrcIP = IPv4SrcIP.substring(0, IPv4SrcIP.length()-1);
+                ctx.ts.IPv4SrcIP = IPv4SrcIP;
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               String IPv6SrcIPHexString = tsRawData.substring(92,124);
+               String IPv6SrcIP = "";
+                for(int i = 0; i < IPv6SrcIPHexString.length(); i = i + 2) {
+                     IPv6SrcIP = IPv6SrcIP + Integer.valueOf(IPv6SrcIPHexString.substring(i, i+2), 16) + ".";
+                }
+                IPv6SrcIP = IPv6SrcIP.substring(0, IPv6SrcIP.length()-1);
+                ctx.ts.IPv6SrcIP = IPv6SrcIP;
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               String IPv4DestIPHexString = tsRawData.substring(108, 116);
+               String IPv4DestIP = "";
+                for(int i = 0; i < IPv4DestIPHexString.length(); i = i + 2) {
+                     IPv4DestIP = IPv4DestIP + Integer.valueOf(IPv4DestIPHexString.substring(i, i+2), 16) + ".";
+                }
+                IPv4DestIP = IPv4DestIP.substring(0, IPv4DestIP.length()-1);
+                ctx.ts.IPv4DestIP = IPv4DestIP;
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+             {
+               String IPv6DestIPHexString = tsRawData.substring(124,156);
+               String IPv6DestIP = "";
+                for(int i = 0; i < IPv6DestIPHexString.length(); i = i + 2) {
+                     IPv6DestIP = IPv6DestIP + Integer.valueOf(IPv6DestIPHexString.substring(i, i+2), 16) + ".";
+                }
+                IPv6DestIP = IPv6DestIP.substring(0, IPv6DestIP.length()-1);
+                ctx.ts.IPv6DestIP = IPv6DestIP;
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               ctx.ts.UDGPData = tsRawData.substring(116, 132);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               ctx.ts.UDGPData = tsRawData.substring(156, 172);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               String UDGSrcPortStr =  tsRawData.substring(116, 120);
+               BigInteger UDGSrcPortBigInt = new BigInteger(UDGSrcPortStr, 16);
+               ctx.ts.UDGSrcPort = UDGSrcPortBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               String UDGSrcPortStr =  tsRawData.substring(156, 160);
+               BigInteger UDGSrcPortBigInt = new BigInteger(UDGSrcPortStr, 16);
+               ctx.ts.UDGSrcPort = UDGSrcPortBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               String UDGDstPortStr =  tsRawData.substring(120, 124);
+               BigInteger UDGDstPortBigInt = new BigInteger(UDGDstPortStr, 16);
+               ctx.ts.UDGDstPort = UDGDstPortBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               String UDGDstPortStr =  tsRawData.substring(160, 164);
+               BigInteger UDGDstPortBigInt = new BigInteger(UDGDstPortStr, 16);
+               ctx.ts.UDGDstPort = UDGDstPortBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               String UDGLengthStr =  tsRawData.substring(124, 128);
+               BigInteger UDGLengthBigInt = new BigInteger(UDGLengthStr, 16);
+               ctx.ts.UDGLength = UDGLengthBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               String UDGLengthStr =  tsRawData.substring(164, 168);
+               BigInteger UDGLengthBigInt = new BigInteger(UDGLengthStr, 16);
+               ctx.ts.UDGLength = UDGLengthBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               String UDGChecksumStr =  tsRawData.substring(128, 132);
+               BigInteger UDGChecksumBigInt = new BigInteger(UDGChecksumStr, 16);
+               ctx.ts.UDGChecksum = UDGChecksumBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               String UDGChecksumStr =  tsRawData.substring(168, 172);
+               BigInteger UDGChecksumBigInt = new BigInteger(UDGChecksumStr, 16);
+               ctx.ts.UDGChecksum = UDGChecksumBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               ctx.ts.InBandNetworkTelemetryData = tsRawData.substring(132, 196);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               ctx.ts.InBandNetworkTelemetryData = tsRawData.substring(172, 236);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               ctx.ts.UDPIntShimHeaderData = tsRawData.substring(132, 140);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               ctx.ts.UDPIntShimHeaderData = tsRawData.substring(172, 180);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+               ctx.ts.UDPIntShimHeaderType = tsRawData.substring(132, 133);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+               ctx.ts.UDPIntShimHeaderType = tsRawData.substring(172, 173);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                String udpIntShimNPTStr =  tsRawData.substring(133, 134);
+                BigInteger udpIntShimNPTBigInt =  new BigInteger(udpIntShimNPTStr, 16);
+                BigInteger bitwiseAnd = new BigInteger('C', 16);
+                BigInteger result = udpIntShimNPTBigInt.and(bitwiseAnd);
+                ctx.ts.UDPIntShimHeaderNPT = result.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  String udpIntShimNPTStr =  tsRawData.substring(173, 174);
+                  BigInteger udpIntShimNPTBigInt =  new BigInteger(udpIntShimNPTStr, 16);
+                  BigInteger bitwiseAnd = new BigInteger('C', 16);
+                  BigInteger result = udpIntShimNPTBigInt.and(bitwiseAnd);
+                  ctx.ts.UDPIntShimHeaderNPT = result.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                ctx.ts.UDPIntShimHeaderRes1 = tsRawData.substring(133, 134);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  ctx.ts.UDPIntShimHeaderRes1 = tsRawData.substring(174, 175);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                String lengthStr = tsRawData.substring(134, 136);
+                BigInteger lengthStrBigInt =  new BigInteger(lengthStr, 16);
+                ctx.ts.UDPIntShimHeaderLength= lengthStrBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  String lengthStr = tsRawData.substring(174, 176);
+                  BigInteger lengthStrBigInt =  new BigInteger(lengthStr, 16);
+                  ctx.ts.UDPIntShimHeaderLength = lengthStrBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                ctx.ts.UDPIntShimHeaderRes2 = tsRawData.substring(136, 138);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  ctx.ts.UDPIntShimHeaderRes2 = tsRawData.substring(176, 178);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 String nextProtoStr = tsRawData.substring(138, 140);
+                 BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+                ctx.ts.UDPIntShimHeaderNextProto = nextProtoBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                   String nextProtoStr = tsRawData.substring(178, 180);
+                   BigInteger nextProtoBigInt =  new BigInteger(nextProtoStr, 16);
+                  ctx.ts.UDPIntShimHeaderNextProto = nextProtoBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 ctx.ts.INTMetadataHeaderData = tsRawData.substring(140, 164);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                   ctx.ts.INTMetadataHeaderData =  tsRawData.substring(180, 204);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 String UDPIntMetaDataHeaderVersionStr = tsRawData.substring(140, 141);
+                BigInteger UDPIntMetaDataHeaderVersionStrBigInt =  new BigInteger(UDPIntMetaDataHeaderVersionStr, 16);
+                ctx.ts.UDPIntMetaDataHeaderVersion =  UDPIntMetaDataHeaderVersionStrBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                String UDPIntMetaDataHeaderVersionStr = tsRawData.substring(180, 181);
+                BigInteger UDPIntMetaDataHeaderVersionStrBigInt =  new BigInteger(UDPIntMetaDataHeaderVersionStr, 16);
+                ctx.ts.UDPIntMetaDataHeaderVersion =  UDPIntMetaDataHeaderVersionStrBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                String UDPIntMetaDataHeaderRes = tsRawData.substring(141, 142);
+                BigInteger UDPIntMetaDataHeaderResBigInt =  new BigInteger(UDPIntMetaDataHeaderRes, 16);
+                BigInteger bitwiseAnd = new BigInteger('C', 16);
+                BigInteger result = UDPIntMetaDataHeaderResBigInt.and(bitwiseAnd);
+                ctx.ts.UDPIntMetaDataHeaderRes =  result.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                String UDPIntMetaDataHeaderRes = tsRawData.substring(181, 182);
+                BigInteger UDPIntMetaDataHeaderResBigInt =  new BigInteger(UDPIntMetaDataHeaderRes, 16);
+                BigInteger bitwiseAnd = new BigInteger('C', 16);
+                BigInteger result = UDPIntMetaDataHeaderResBigInt.and(bitwiseAnd);
+                ctx.ts.UDPIntMetaDataHeaderRes =  result.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                String UDPIntMetaDataHeaderD = tsRawData.substring(141, 142);
+                BigInteger UDPIntMetaDataHeaderDBigInt =  new BigInteger(UDPIntMetaDataHeaderD, 16);
+                BigInteger bitwiseAnd = new BigInteger('2', 16);
+                BigInteger result = UDPIntMetaDataHeaderDBigInt.and(bitwiseAnd);
+                ctx.ts.UDPIntMetaDataHeaderD =  result.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                String UDPIntMetaDataHeaderD =  tsRawData.substring(181, 182);
+                BigInteger UDPIntMetaDataHeaderDBigInt =  new BigInteger(UDPIntMetaDataHeaderD, 16);
+                BigInteger bitwiseAnd = new BigInteger('2', 16);
+                BigInteger result = UDPIntMetaDataHeaderDBigInt.and(bitwiseAnd);
+                ctx.ts.UDPIntMetaDataHeaderD =  result.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                  String UDPIntMetaDataHeaderE = tsRawData.substring(141, 142);
+                  BigInteger UDPIntMetaDataHeaderEBigInt =  new BigInteger(UDPIntMetaDataHeaderE, 16);
+                  BigInteger bitwiseAnd = new BigInteger('1', 16);
+                  BigInteger result = UDPIntMetaDataHeaderEBigInt.and(bitwiseAnd);
+                  ctx.ts.UDPIntMetaDataHeaderE =  result.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                 String UDPIntMetaDataHeaderE = tsRawData.substring(181, 182);
+                 BigInteger UDPIntMetaDataHeaderEBigInt =  new BigInteger(UDPIntMetaDataHeaderE, 16);
+                 BigInteger bitwiseAnd = new BigInteger('1', 16);
+                 BigInteger result = UDPIntMetaDataHeaderEBigInt.and(bitwiseAnd);
+                 ctx.ts.UDPIntMetaDataHeaderE =  result.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                  String UDPIntMetaDataHeaderM = tsRawData.substring(142, 143);
+                  BigInteger UDPIntMetaDataHeaderMBigInt =  new BigInteger(UDPIntMetaDataHeaderM, 16);
+                  BigInteger bitwiseAnd = new BigInteger('8', 16);
+                  BigInteger result = UDPIntMetaDataHeaderMBigInt.and(bitwiseAnd);
+                  ctx.ts.UDPIntMetaDataHeaderM =  result.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  String UDPIntMetaDataHeaderM = tsRawData.substring(182, 183);
+                  BigInteger UDPIntMetaDataHeaderMBigInt =  new BigInteger(UDPIntMetaDataHeaderM, 16);
+                  BigInteger bitwiseAnd = new BigInteger('8', 16);
+                  BigInteger result = UDPIntMetaDataHeaderMBigInt.and(bitwiseAnd);
+                  ctx.ts.UDPIntMetaDataHeaderM =  result.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                  String UDPIntMetaDataHeaderPerhopMetadataLengthStr = tsRawData.substring(144, 146);
+                  BigInteger UDPIntMetaDataHeaderPerhopMetadataLengthBigInt =  new BigInteger(UDPIntMetaDataHeaderPerhopMetadataLengthStr, 16);
+                  BigInteger bitwiseAnd = new BigInteger('1F', 16);
+                  BigInteger result = UDPIntMetaDataHeaderPerhopMetadataLengthBigInt.and(bitwiseAnd);
+                  ctx.ts.UDPIntMetaDataHeaderPerhopMetadataLength =  result.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  String UDPIntMetaDataHeaderPerhopMetadataLengthStr =  tsRawData.substring(184, 186);
+                  BigInteger UDPIntMetaDataHeaderPerhopMetadataLengthBigInt =  new BigInteger(UDPIntMetaDataHeaderPerhopMetadataLengthStr, 16);
+                  BigInteger bitwiseAnd = new BigInteger('1F', 16);
+                  BigInteger result = UDPIntMetaDataHeaderPerhopMetadataLengthBigInt.and(bitwiseAnd);
+                  ctx.ts.UDPIntMetaDataHeaderPerhopMetadataLength =  result.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                  String UDPIntMetaDataHeaderRemainingHopCntStr = tsRawData.substring(146, 148);
+                  BigInteger UDPIntMetaDataHeaderRemainingHopCntBigInt =  new BigInteger(UDPIntMetaDataHeaderRemainingHopCntStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderRemainingHopCnt =  UDPIntMetaDataHeaderRemainingHopCntBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  String UDPIntMetaDataHeaderRemainingHopCntStr = tsRawData.substring(186, 188);
+                  BigInteger UDPIntMetaDataHeaderRemainingHopCntBigInt =  new BigInteger(UDPIntMetaDataHeaderRemainingHopCntStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderRemainingHopCnt =  UDPIntMetaDataHeaderRemainingHopCntBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                  String UDPIntMetaDataHeaderInstructionBitmapStr = tsRawData.substring(148, 152);
+                  BigInteger UDPIntMetaDataHeaderInstructionBitmapBigInt =  new BigInteger(UDPIntMetaDataHeaderInstructionBitmapStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderInstructionBitmap =  UDPIntMetaDataHeaderInstructionBitmapBigInt.toString(16);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  String UDPIntMetaDataHeaderInstructionBitmapStr = tsRawData.substring(188, 192);
+                  BigInteger UDPIntMetaDataHeaderInstructionBitmapBigInt =  new BigInteger(UDPIntMetaDataHeaderInstructionBitmapStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderInstructionBitmap =  UDPIntMetaDataHeaderInstructionBitmapBigInt.toString(16);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                  String UDPIntMetaDataHeaderDomainSpecificIDStr = tsRawData.substring(152, 156);
+                  BigInteger UDPIntMetaDataHeaderDomainSpecificIDBigInt =  new BigInteger(UDPIntMetaDataHeaderDomainSpecificIDStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderDomainSpecificID =  UDPIntMetaDataHeaderDomainSpecificIDBigInt.toString(16);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                   String UDPIntMetaDataHeaderDomainSpecificIDStr = tsRawData.substring(192, 196);
+                  BigInteger UDPIntMetaDataHeaderDomainSpecificIDBigInt =  new BigInteger(UDPIntMetaDataHeaderDomainSpecificIDStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderDomainSpecificID =  UDPIntMetaDataHeaderDomainSpecificIDBigInt.toString(16);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                  String UDPIntMetaDataHeaderDSInstructionStr = tsRawData.substring(156, 160);
+                  BigInteger UDPIntMetaDataHeaderDSInstructionBigInt =  new BigInteger(UDPIntMetaDataHeaderDSInstructionStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderDSInstruction =  UDPIntMetaDataHeaderDSInstructionBigInt.toString(16);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                   String UDPIntMetaDataHeaderDSInstructionStr = tsRawData.substring(196, 200);
+                  BigInteger UDPIntMetaDataHeaderDSInstructionBigInt =  new BigInteger(UDPIntMetaDataHeaderDSInstructionStr, 16);
+                  ctx.ts.UDPIntMetaDataHeaderDSInstruction =  UDPIntMetaDataHeaderDSInstructionBigInt.toString(16);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 String UDPIntMetaDataHeaderDSFlagsStr = tsRawData.substring(160, 164);
+                 BigInteger UDPIntMetaDataHeaderDSFlagsBigInt =  new BigInteger(UDPIntMetaDataHeaderDSFlagsStr, 16);
+                 ctx.ts.UDPIntMetaDataHeaderDSFlags = UDPIntMetaDataHeaderDSFlagsBigInt.toString(16);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                 String UDPIntMetaDataHeaderDSFlagsStr = tsRawData.substring(200, 204);
+                 BigInteger UDPIntMetaDataHeaderDSFlagsBigInt =  new BigInteger(UDPIntMetaDataHeaderDSFlagsStr, 16);
+                 ctx.ts.UDPIntMetaDataHeaderDSFlags = UDPIntMetaDataHeaderDSFlagsBigInt.toString(16);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 ctx.ts.INTMetadataStackData = tsRawData.substring(164, 196);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                 ctx.ts.INTMetadataStackData = tsRawData.substring(204, 236);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 ctx.ts.INTMetadataStackSwitchID = tsRawData.substring(164, 172);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  ctx.ts.INTMetadataStackSwitchID = tsRawData.substring(204, 212);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 ctx.ts.INTMetadataSourceMetadata = tsRawData.substring(172, 196);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  ctx.ts.INTMetadataSourceMetadata = tsRawData.substring(212, 236);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 ctx.ts.INTMetadataSourceMetadataSwitchId = tsRawData.substring(172, 180);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  ctx.ts.INTMetadataSourceMetadataSwitchId = tsRawData.substring(212, 220);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 ctx.ts.INTMetadataSourceMetadataOriginatingMac = tsRawData.substring(180, 192);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  ctx.ts.INTMetadataSourceMetadataOriginatingMac = tsRawData.substring(220, 232);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              if( etherType == '0800' && ipVersion == '4')
+              {
+                 ctx.ts.INTMetadataSourceMetadataReserved = tsRawData.substring(192, 196);
+              }
+              if( etherType == '86dd' && ipVersion == '6')
+              {
+                  ctx.ts.INTMetadataSourceMetadataReserved = tsRawData.substring(232, 236);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+
+            {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              String tcpNextProtoStr = '6';
+              int tcpNextProtoInt = Integer.parseInt(tcpNextProtoStr);
+              if( etherType == '0800' && ipVersion == '4' &&  ctx.ts.nextProto == tcpNextProtoInt )
+              {
+               ctx.ts.TCPData = tsRawData.substring(196, 236);
+              }
+              if(etherType == '86dd' && ipVersion == '6' &&  ctx.ts.nextProto == tcpNextProtoInt )
+              {
+               ctx.ts.TCPData = tsRawData.substring(236, 276);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              String tcpNextProtoStr = '6';
+              int tcpNextProtoInt = Integer.parseInt(tcpNextProtoStr);
+              if( etherType == '0800' && ipVersion == '4' &&  ctx.ts.nextProto == tcpNextProtoInt )
+              {
+               String TCPSrcPortStr = tsRawData.substring(196, 200);
+               BigInteger TCPSrcPortBigInt = new BigInteger(TCPSrcPortStr,16);
+               ctx.ts.TCPSrcPort = TCPSrcPortBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6' &&  ctx.ts.nextProto == tcpNextProtoInt )
+              {
+               String TCPSrcPortStr = tsRawData.substring(236, 240);
+               BigInteger TCPSrcPortBigInt = new BigInteger(TCPSrcPortStr,16);
+               ctx.ts.TCPSrcPort = TCPSrcPortBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              String tcpNextProtoStr = '6';
+              int tcpNextProtoInt = Integer.parseInt(tcpNextProtoStr);
+              if( etherType == '0800' && ipVersion == '4' &&  ctx.ts.nextProto == tcpNextProtoInt )
+              {
+               String TCPDstPortStr = tsRawData.substring(200, 204);
+               BigInteger TCPDstPortBigInt = new BigInteger(TCPDstPortStr,16);
+               ctx.ts.TCPDestPort = TCPDstPortBigInt.intValue();
+              }
+              if( etherType == '86dd' && ipVersion == '6' &&  ctx.ts.nextProto == tcpNextProtoInt )
+              {
+               String TCPDstPortStr = tsRawData.substring(240, 244);
+               BigInteger TCPDstPortBigInt = new BigInteger(TCPDstPortStr,16);
+               ctx.ts.TCPDestPort = TCPDstPortBigInt.intValue();
+              }
+        """,
+          "ignore_failure" : true
+        }
+      },
+
+      {
+        "script" : {
+          "lang" : "painless",
+          "source" : """
+              String tsRawData = ctx.layers.data.data_data_data.replace(':','');
+              String etherType = tsRawData.substring(72, 76);
+              String ipVersion = tsRawData.substring(76, 77);
+              String tcpNextProtoStr = '6';
+              int tcpNextProtoInt = Integer.parseInt(tcpNextProtoStr);
+              if( etherType == '0800' && ipVersion == '4' &&  ctx.ts.nextProto == tcpNextProtoInt)
+              {
+                 ctx.ts.dataII = tsRawData.substring(236, 288);
+              }
+              if(etherType == '86dd' && ipVersion == '6' &&  ctx.ts.nextProto == tcpNextProtoInt)
+              {
+                 ctx.ts.dataII = tsRawData.substring(252, 304);
+              }
+        """,
+          "ignore_failure" : true
+        }
+      }
+    ]
+}

--- a/playbooks/scenarios/general/arping.yml
+++ b/playbooks/scenarios/general/arping.yml
@@ -28,3 +28,13 @@
       retries: 3
       delay: 3
       until: out is not failed
+
+    - name: Delete add IPv6 neighbor if exists
+      command: "sudo ip -6 neigh del {{ receiver.ipv6 }} lladdr {{ receiver.mac }} dev {{ arp_intf }}"
+      ignore_errors: yes
+
+    - name: Manually add IPv6 neighbor
+      command: "sudo ip -6 neigh add {{ receiver.ipv6 }} lladdr {{ receiver.mac }} dev {{ arp_intf }}"
+
+    - name: Make neighbor reachable
+      command: "sudo ip -6 neigh chg {{ receiver.ipv6 }} dev {{ arp_intf }} nud reachable"

--- a/playbooks/scenarios/lab_trial/iperf.yml
+++ b/playbooks/scenarios/lab_trial/iperf.yml
@@ -24,6 +24,7 @@
     iperf_server: inet
     iperf_client: host1
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"
 
 - import_playbook: ../test_cases/run_iperf.yml
   vars:
@@ -31,6 +32,7 @@
     iperf_server: inet
     iperf_client: host2
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"
 
 - import_playbook: ../test_cases/run_iperf.yml
   vars:
@@ -38,6 +40,7 @@
     iperf_server: ae
     iperf_client: host1
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"
 
 - import_playbook: ../test_cases/run_iperf.yml
   vars:
@@ -45,6 +48,7 @@
     iperf_server: ae
     iperf_client: host2
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"
 
 - import_playbook: ../test_cases/run_iperf.yml
   vars:
@@ -52,6 +56,7 @@
     iperf_server: host1
     iperf_client: inet
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"
 
 - import_playbook: ../test_cases/run_iperf.yml
   vars:
@@ -59,6 +64,7 @@
     iperf_server: host1
     iperf_client: ae
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"
 
 - import_playbook: ../test_cases/run_iperf.yml
   vars:
@@ -66,6 +72,7 @@
     iperf_server: host2
     iperf_client: inet
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"
 
 - import_playbook: ../test_cases/run_iperf.yml
   vars:
@@ -73,3 +80,4 @@
     iperf_server: host2
     iperf_client: ae
     iperf_server_ip: "{{ topo_dict.hosts[iperf_server].ip }}"
+    iperf_server_ipv6: "{{ topo_dict.hosts[iperf_server].ipv6 }}"

--- a/playbooks/scenarios/test_cases/run_iperf.yml
+++ b/playbooks/scenarios/test_cases/run_iperf.yml
@@ -32,12 +32,34 @@
   vars:
     receive_timeout: "{{ iperf3_receive_timeout | default(60) }}"
   tasks:
-    - name: Checking speed with iperf3 against {{ iperf_server_ip }}
-      command: "iperf3 -c {{ iperf_server_ip }}"
-      register: cmd_out
-      changed_when: cmd_out is not failed
-      async: "{{ receive_timeout }}"
+    - name: Run when IPv4 address is defined
+      block:
+        - name: Checking speed with iperf3 against {{ iperf_server_ip | ansible.netcommon.ipaddr }}
+          command: "iperf3 -c {{ iperf_server_ip }}"
+          register: cmd_out
+          changed_when: cmd_out is not failed
+          async: "{{ receive_timeout }}"
 
-    - name: Iperf results
-      debug:
-        var: cmd_out
+        - name: Iperf results
+          debug:
+            var: cmd_out
+      when: iperf_server_ip is defined
+
+# Start iperf client
+- hosts: "{{ iperf_client }}"
+  gather_facts: no
+  vars:
+    receive_timeout: "{{ iperf3_receive_timeout | default(60) }}"
+  tasks:
+    - name: Run when IPv6 address is defined
+      block:
+      - name: Checking speed with iperf3 against {{ iperf_server_ipv6 | ansible.netcommon.ipaddr }}
+        command: "iperf3 -c {{ iperf_server_ipv6 | ansible.netcommon.ipaddr }}"
+        register: cmd_out
+        changed_when: cmd_out is not failed
+        async: "{{ receive_timeout }}"
+
+      - name: Iperf results
+        debug:
+          var: cmd_out
+      when: iperf_server_ipv6 is defined

--- a/playbooks/scenarios/test_cases/send_receive.yml
+++ b/playbooks/scenarios/test_cases/send_receive.yml
@@ -57,27 +57,12 @@
         receive_cmd: >
           {{ trans_sec_dir }}/trans_sec/device_software/receive_packets.py
           -i {{ receiver_intf }} -f {{ receiver_log_file }} -d {{ receive_timeout }} -ih {{ hops }}
-      when: receiver_intf is defined and receiver_intf | length > 0
-
-    - name: Create receive packets command with the receiver_ipv4 variable
-      set_fact:
-        receive_cmd: >
-          {{ trans_sec_dir }}/trans_sec/device_software/receive_packets.py
-          -dip4 {{ receiver_ipv4 }} -f {{ receiver_log_file }} -d {{ receive_timeout }} -ih {{ hops }}
-      when: receiver_ipv4 is defined and receiver_ipv4 | length > 0
-
-    - name: Fail when receive command was not created
-      fail:
-        msg: 'Receive command could not be generated'
-      when: receive_cmd is not defined or receive_cmd | length < 1
 
     - name: The receive command
       debug:
         var: receive_cmd
 
-    - name: >
-        Receive and log packets from "{{ receiver.name }}" logged at {{ receiver_log_file }}
-        with async timeout {{ receive_timeout }} for potentially {{ send_packet_count }} packets
+    - name: Receive and log packets with {{ receive_cmd }}
       command: "{{ receive_cmd }}"
       register: cmd_out
       changed_when: cmd_out is not failed
@@ -132,11 +117,6 @@
           -it {{ loops }} -itd {{ loop_delay }}
           -pr {{ send_protocol }}
           -c {{ send_packet_count }}
-
-    - name: Add receiver ipv4 to send_packets.py call for dst_mac ARP table lookup
-      set_fact:
-        send_cmd: "{{ send_cmd }} -dip4 {{ receiver_ipv4 }}"
-      when: arp_discovery is defined and arp_discovery|bool
 
     - name: Add known dst_mac to send_packets.py call
       set_fact:

--- a/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
+++ b/playbooks/tofino/templates/topology_template-lab_trial.yaml.j2
@@ -44,7 +44,7 @@ hosts:
     tun1_mac: {{ host2_tun1_mac }}
     tunnels:
       - host: aggregate
-    ipv6: 0000:0000:0000:0000:0000:0001:0001:0003
+    ipv6: 0000:0000:0000:0000:0000:0001:0001:0006
     ip_port: any
     mac: 00:00:00:00:01:02
     type: nas
@@ -61,7 +61,7 @@ hosts:
     tun1_mac: {{ inet_tun1_mac }}
     tunnels:
       - host: core
-    ipv6: 0000:0000:0000:0000:0000:0001:0001:0003
+    ipv6: 0000:0000:0000:0000:0000:0001:0001:0010
     ip_port: any
     mac: 00:00:00:00:05:01
     type: nas
@@ -78,7 +78,7 @@ hosts:
     tun1_mac: {{ ae_tun1_mac }}
     tunnels:
       - host: core
-    ipv6: 0000:0000:0000:0000:0000:0002:0001:0003
+    ipv6: 0000:0000:0000:0000:0000:0001:0001:001d
     ip_port: any
     mac: 00:00:00:00:05:02
     type: server

--- a/playbooks/tofino/tunnel/gre_tunnel_tasks.yml
+++ b/playbooks/tofino/tunnel/gre_tunnel_tasks.yml
@@ -98,9 +98,15 @@
 
 - name: Setup host tunnel to switch port with expected IP/MAC
   block:
-    - name: set MAC {{ this_host.mac }} on {{ mirrored_host_intf }}
+    - name: set MAC {{ this_host.mac }} on {{ tunnel1 }}
       command: "ip link set dev {{ tunnel1 }} address {{ this_host.mac }}"
 
-    - name: Set IP {{ this_host.ip }}/24 on {{ mirrored_host_intf }}
+    - name: Set IP {{ this_host.ip }}/24 on {{ tunnel1 }}
       command: "ip addr add {{ this_host.ip }}/24 dev {{ tunnel1 }}"
+
+    - name: Set IP {{ this_host.ipv6 }}/64 on {{ tunnel1 }}
+      command: "ip -6 addr add {{ this_host.ipv6 }}/64 dev {{ tunnel1 }}"
+
+    - name: Set ipv6 route - TODO - make me dynamic
+      command: "ip -6 route add ::1:0:0 dev {{ tunnel1 }}"
   when: item.switch_port is not defined

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ipaddress
 netaddr
 mock==4.0.2
 python_arptable
+get-mac

--- a/trans_sec/device_software/receive_packets.py
+++ b/trans_sec/device_software/receive_packets.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-from python_arptable import ARPTABLE
 import logging
 import sys
 
@@ -50,10 +49,6 @@ def get_args():
         '-l', '--loglevel',
         help='Log Level <DEBUG|INFO|WARNING|ERROR> defaults to INFO',
         required=False, default='DEBUG', dest='log_level')
-    parser.add_argument(
-        '-dip4', '--dst_ipv4',
-        help='Destination ipv4 for ARP table lookup for interface to use',
-        required=False)
     return parser.parse_args()
 
 
@@ -267,13 +262,6 @@ def device_sniff(iface, duration, int_hops):
               prn=lambda packet: __log_packet(packet, int_hops))
 
 
-def __get_iface_from_arptable(ipv4):
-    for arp_entry in ARPTABLE:
-        if arp_entry['IP address'] == ipv4:
-            logger.info('Returning device name from entry - [%s]', arp_entry)
-            return arp_entry['Device']
-
-
 if __name__ == '__main__':
     args = get_args()
 
@@ -287,11 +275,5 @@ if __name__ == '__main__':
 
     logger.info('Logger initialized')
 
-    iface = None
-    if args.dst_ipv4:
-        iface = __get_iface_from_arptable(args.dst_ipv4)
-    if not iface:
-        iface = args.iface
-
-    logger.info('Sniffing for packets on interface - [%s]', iface)
-    device_sniff(iface, args.duration, args.int_hops)
+    logger.info('Sniffing for packets on interface - [%s]', args.iface)
+    device_sniff(args.iface, args.duration, args.int_hops)


### PR DESCRIPTION
#### What does this PR do?
Fixes #315 
Manually added neighbor entry (IPv6 equivalent to ARP) to ip dev switch tunnel for IPv6 L2 ipv6_routing
Removed -dip4 hook for destination MAC lookups (send_packets.py) and interface (receive_packets.py) in the test code. Now lookups are ocurring using the destination IP address from ARP cache for IPv4 & using get-mac library getmac.get_mac_address() for IPv6. 
Fixed IPv6 addresses in lab_trial topology (inet & host2 had same & ae was in a different subnet)

iperf3 will now work with IPv6 endpoints
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
Ensure CI doesn't fail
#### Any background context you want to provide?
Need to ensure IPv6 works like IPv6
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? Python - get-mac
- Have you added unit or functional tests for this PR? Updated the existing to reflect changes as well as added an additional call on the test client to IPv6 endpoints in the iperf.yml test case
