### PR TITLE
Swagger ws doc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cygrpc
 grpcio
 python-dateutil
 flask
-flask_restful
+flask-restful-swagger-3
 ipaddress
 netaddr
 mock==4.0.2

--- a/trans_sec/controller/http_server_flask.py
+++ b/trans_sec/controller/http_server_flask.py
@@ -16,12 +16,10 @@ import threading
 
 import requests
 from flask import Flask, request
-from flask_restful import Resource, Api, reqparse
+from flask_restful import reqparse
+from flask_restful_swagger_3 import swagger, Resource, Api, Schema
 
 logger = logging.getLogger('http_server_handler')
-
-
-http_server = Flask('sdn_controller_api_server')
 
 
 class SDNControllerServer:
@@ -30,7 +28,8 @@ class SDNControllerServer:
         self.port = port
         self.host = host
         self.thread = threading.Thread(target=self.flask_thread)
-        self.api = Api(http_server)
+        self.http_server = Flask('sdn_controller_api_server')
+        self.api = Api(self.http_server)
         self.server_start = None
 
     def start(self):
@@ -64,7 +63,8 @@ class SDNControllerServer:
 
     def flask_thread(self):
         logger.info('Starting server on port [%s]', self.port)
-        self.server_start = http_server.run(host=self.host, port=self.port)
+        self.server_start = self.http_server.run(host=self.host,
+                                                 port=self.port)
 
 
 class DataForward(Resource):
@@ -72,22 +72,36 @@ class DataForward(Resource):
     Class for exposing web service to enter a data_forward entry into the P4
     gateway.p4
     """
+    parser = reqparse.RequestParser()
+    parser.add_argument('device_id', type=int, default=0)
+    parser.add_argument('switch_mac', type=str)
+    parser.add_argument('dst_mac', type=str)
+    parser.add_argument('output_port', type=int)
+
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument('device_id', type=int, default=0)
-        self.parser.add_argument('dst_mac', type=str)
-        self.parser.add_argument('output_port', type=int)
-        self.parser.add_argument('switch_mac', type=str)
 
+    @swagger.tags(['dataForwardPost'])
+    @swagger.response(response_code=201,
+                      description='Added data_forward entry')
+    @swagger.reqparser(name='DataForwardParser', parser=parser)
     def post(self):
         logger.info('Data forward entry requested')
+        parser = reqparse.RequestParser()
+        parser.add_argument('device_id', type=int, default=0)
+        parser.add_argument('switch_mac', type=str)
+        parser.add_argument('dst_mac', type=str)
+        parser.add_argument('output_port', type=int)
         args = self.parser.parse_args()
 
         logger.info('Data forward args - [%s]', args)
         self.sdn_controller.add_data_forward(args)
         return json.dumps({"success": True}), 201
 
+    @swagger.tags(['dataForwardDelete'])
+    @swagger.response(response_code=201,
+                      description='Delete data_forward entry')
+    @swagger.reqparser(name='DataForwardParser', parser=parser)
     def delete(self):
         logger.info('Data forward entry to remove')
         args = self.parser.parse_args()
@@ -102,13 +116,18 @@ class DataInspection(Resource):
     Class for exposing web service to enter a data_forward entry into the P4
     gateway.p4
     """
+    parser = reqparse.RequestParser()
+    parser.add_argument('device_id', type=int, default=0)
+    parser.add_argument('switch_mac', type=str)
+    parser.add_argument('device_mac', type=str)
+
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument('device_id', type=int, default=0)
-        self.parser.add_argument('switch_mac', type=str)
-        self.parser.add_argument('device_mac', type=str)
 
+    @swagger.tags(['dataInspectionPost'])
+    @swagger.response(response_code=201,
+                      description='Added data_inspection entry')
+    @swagger.reqparser(name='DataInspectionParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
         args = self.parser.parse_args()
@@ -117,6 +136,10 @@ class DataInspection(Resource):
         self.sdn_controller.add_data_inspection(args)
         return json.dumps({"success": True}), 201
 
+    @swagger.tags(['dataInspectionDelete'])
+    @swagger.response(response_code=201,
+                      description='Added data_inspection deletion')
+    @swagger.reqparser(name='DataInspectionParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
         args = self.parser.parse_args()
@@ -130,17 +153,22 @@ class GwAttack(Resource):
     """
     Class for exposing web service to issue an attack call to gateway.p4
     """
+
+    parser = reqparse.RequestParser()
+    parser.add_argument('src_mac', type=str)
+    parser.add_argument('src_ip', type=str)
+    parser.add_argument('dst_ip', type=str)
+    parser.add_argument('dst_port', type=str)
+    parser.add_argument('packet_size', type=str)
+    parser.add_argument('attack_type', type=str)
+
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']
 
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument('src_mac', type=str)
-        self.parser.add_argument('src_ip', type=str)
-        self.parser.add_argument('dst_ip', type=str)
-        self.parser.add_argument('dst_port', type=str)
-        self.parser.add_argument('packet_size', type=str)
-        self.parser.add_argument('attack_type', type=str)
-
+    @swagger.tags(['gatewayAttackStart'])
+    @swagger.response(response_code=201,
+                      description='Mitigate attack')
+    @swagger.reqparser(name='GwAttackParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
         args = self.parser.parse_args()
@@ -149,6 +177,10 @@ class GwAttack(Resource):
         self.sdn_controller.add_attacker(args)
         return json.dumps({"success": True}), 201
 
+    @swagger.tags(['gatewayAttackStop'])
+    @swagger.response(response_code=201,
+                      description='Unmitigate attack')
+    @swagger.reqparser(name='GwAttackParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
         args = self.parser.parse_args()
@@ -163,13 +195,18 @@ class AggDataForward(Resource):
     Class for exposing web service to enter a data_forward entry into the P4
     aggregate.p4
     """
+    parser = reqparse.RequestParser()
+    parser.add_argument('device_id', type=str, default=0)
+    parser.add_argument('dst_mac', type=str)
+    parser.add_argument('output_port', type=str)
+
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument('device_id', type=str, default=0)
-        self.parser.add_argument('dst_mac', type=str)
-        self.parser.add_argument('output_port', type=str)
 
+    @swagger.tags(['aggDataForwardAdd'])
+    @swagger.response(response_code=201,
+                      description='Add data forward to aggregate')
+    @swagger.reqparser(name='AggDataForwardParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
         args = self.parser.parse_args()
@@ -178,6 +215,10 @@ class AggDataForward(Resource):
         self.sdn_controller.add_agg_data_forward(args)
         return json.dumps({"success": True}), 201
 
+    @swagger.tags(['aggDataForwardDelete'])
+    @swagger.response(response_code=201,
+                      description='Delete data forward from aggregate')
+    @swagger.reqparser(name='AggDataForwardParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
         args = self.parser.parse_args()
@@ -191,13 +232,18 @@ class AggAttack(Resource):
     """
     Class for exposing web service to issue an attack call to aggregate.p4
     """
+    parser = reqparse.RequestParser()
+    parser.add_argument('src_mac', type=str)
+    parser.add_argument('dst_ip', type=str)
+    parser.add_argument('dst_port', type=str)
+
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument('src_mac', type=str)
-        self.parser.add_argument('dst_ip', type=str)
-        self.parser.add_argument('dst_port', type=str)
 
+    @swagger.tags(['aggAttackStart'])
+    @swagger.response(response_code=201,
+                      description='Mitigate attack on aggregate')
+    @swagger.reqparser(name='AggAttackParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
         args = self.parser.parse_args()
@@ -206,6 +252,10 @@ class AggAttack(Resource):
         self.sdn_controller.add_agg_attacker(args)
         return json.dumps({"success": True}), 201
 
+    @swagger.tags(['aggAttackStop'])
+    @swagger.response(response_code=201,
+                      description='Unmitigate attack on aggregate')
+    @swagger.reqparser(name='AggAttackParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
         args = self.parser.parse_args()
@@ -215,11 +265,20 @@ class AggAttack(Resource):
         return json.dumps({"success": True}), 201
 
 
-class CoreDataForward(AggDataForward):
+class CoreDataForward(Resource):
     """
     Class for exposing web service to enter a data_forward entry into the P4
     core.p4
     """
+    parser = reqparse.RequestParser()
+    parser.add_argument('device_id', type=str, default=0)
+    parser.add_argument('dst_mac', type=str)
+    parser.add_argument('output_port', type=str)
+
+    @swagger.tags(['coreDataForwardAdd'])
+    @swagger.response(response_code=201,
+                      description='Add data forward to core')
+    @swagger.reqparser(name='CoreDataForwardParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
         args = self.parser.parse_args()
@@ -228,6 +287,10 @@ class CoreDataForward(AggDataForward):
         self.sdn_controller.add_core_data_forward(args)
         return json.dumps({"success": True}), 201
 
+    @swagger.tags(['coreDataForwardDel'])
+    @swagger.response(response_code=201,
+                      description='Delete data forward entry in core')
+    @swagger.reqparser(name='CoreDataForwardParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
         args = self.parser.parse_args()
@@ -241,14 +304,19 @@ class TelemetryReport(Resource):
     """
     Class for exposing web service to issue an attack call to aggregate.p4
     """
+    parser = reqparse.RequestParser()
+    parser.add_argument('device_id', type=int, default=0)
+    parser.add_argument('switch_mac', type=str)
+    parser.add_argument('port', type=str)
+    parser.add_argument('ae_ip', type=str)
+
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument('device_id', type=int, default=0)
-        self.parser.add_argument('switch_mac', type=str)
-        self.parser.add_argument('port', type=str)
-        self.parser.add_argument('ae_ip', type=str)
 
+    @swagger.tags(['telemetryRptAdd'])
+    @swagger.response(response_code=201,
+                      description='Configure endpoint for Telemetry Report')
+    @swagger.reqparser(name='TelemRptParser', parser=parser)
     def post(self):
         logger.info('Activating telemetry report')
         args = self.parser.parse_args()
@@ -257,6 +325,10 @@ class TelemetryReport(Resource):
         self.sdn_controller.activate_telem_rpt(args)
         return json.dumps({"success": True}), 201
 
+    @swagger.tags(['telemetryRptDel'])
+    @swagger.response(response_code=201,
+                      description='Unconfigure endpoint for Telemetry Report')
+    @swagger.reqparser(name='TelemRptParser', parser=parser)
     def delete(self):
         logger.info('Deactivating telemetry report')
         args = self.parser.parse_args()
@@ -272,11 +344,17 @@ class TelemetryReportSampling(Resource):
     value. i.e. When "count" == 0, every INT packet will generate a Telem rpt
                 when "count" == 1, every other; 2 - every third etc
     """
+    parser = reqparse.RequestParser()
+    parser.add_argument('sample', type=int, default=0)
+
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']
-        self.parser = reqparse.RequestParser()
-        self.parser.add_argument('sample', type=int, default=0)
 
+    @swagger.tags(['telemetryRptSample'])
+    @swagger.response(response_code=201,
+                      description='Configure sampling value for the '
+                                  'Telemetry Report')
+    @swagger.reqparser(name='TelemRptSampleParser', parser=parser)
     def post(self):
         logger.info('Setting Telemetry report sampling value')
         args = self.parser.parse_args()

--- a/trans_sec/controller/http_server_flask.py
+++ b/trans_sec/controller/http_server_flask.py
@@ -29,7 +29,8 @@ class SDNControllerServer:
         self.host = host
         self.thread = threading.Thread(target=self.flask_thread)
         self.http_server = Flask('sdn_controller_api_server')
-        self.api = Api(self.http_server)
+        self.api = Api(self.http_server, title='TPS Controller API',
+                       description='APIs for some basic P4 CRUD operations')
         self.server_start = None
 
     def start(self):
@@ -100,7 +101,7 @@ class DataForward(Resource):
 
     @swagger.tags(['dataForwardDelete'])
     @swagger.response(response_code=201,
-                      description='Delete data_forward entry')
+                      description='Deleted data_forward entry')
     @swagger.reqparser(name='DataForwardParser', parser=parser)
     def delete(self):
         logger.info('Data forward entry to remove')
@@ -138,7 +139,7 @@ class DataInspection(Resource):
 
     @swagger.tags(['dataInspectionDelete'])
     @swagger.response(response_code=201,
-                      description='Added data_inspection deletion')
+                      description='Deleted data_inspection deletion')
     @swagger.reqparser(name='DataInspectionParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
@@ -167,7 +168,7 @@ class GwAttack(Resource):
 
     @swagger.tags(['gatewayAttackStart'])
     @swagger.response(response_code=201,
-                      description='Mitigate attack')
+                      description='Mitigated attack on gateway')
     @swagger.reqparser(name='GwAttackParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
@@ -179,7 +180,7 @@ class GwAttack(Resource):
 
     @swagger.tags(['gatewayAttackStop'])
     @swagger.response(response_code=201,
-                      description='Unmitigate attack')
+                      description='Unmitigated attacks from gateway')
     @swagger.reqparser(name='GwAttackParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
@@ -205,7 +206,7 @@ class AggDataForward(Resource):
 
     @swagger.tags(['aggDataForwardAdd'])
     @swagger.response(response_code=201,
-                      description='Add data forward to aggregate')
+                      description='Added data forward entry to aggregate')
     @swagger.reqparser(name='AggDataForwardParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
@@ -217,7 +218,7 @@ class AggDataForward(Resource):
 
     @swagger.tags(['aggDataForwardDelete'])
     @swagger.response(response_code=201,
-                      description='Delete data forward from aggregate')
+                      description='Deleted data forward entry from aggregate')
     @swagger.reqparser(name='AggDataForwardParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
@@ -242,7 +243,7 @@ class AggAttack(Resource):
 
     @swagger.tags(['aggAttackStart'])
     @swagger.response(response_code=201,
-                      description='Mitigate attack on aggregate')
+                      description='Mitigated attacks from aggregate')
     @swagger.reqparser(name='AggAttackParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
@@ -254,7 +255,7 @@ class AggAttack(Resource):
 
     @swagger.tags(['aggAttackStop'])
     @swagger.response(response_code=201,
-                      description='Unmitigate attack on aggregate')
+                      description='Unmitigated attacks from aggregate')
     @swagger.reqparser(name='AggAttackParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
@@ -277,7 +278,7 @@ class CoreDataForward(Resource):
 
     @swagger.tags(['coreDataForwardAdd'])
     @swagger.response(response_code=201,
-                      description='Add data forward to core')
+                      description='Added data forward entry to core')
     @swagger.reqparser(name='CoreDataForwardParser', parser=parser)
     def post(self):
         logger.info('Attack requested')
@@ -289,7 +290,7 @@ class CoreDataForward(Resource):
 
     @swagger.tags(['coreDataForwardDel'])
     @swagger.response(response_code=201,
-                      description='Delete data forward entry in core')
+                      description='Deleted data forward entry from core')
     @swagger.reqparser(name='CoreDataForwardParser', parser=parser)
     def delete(self):
         logger.info('Attacker to remove')
@@ -327,7 +328,7 @@ class TelemetryReport(Resource):
 
     @swagger.tags(['telemetryRptDel'])
     @swagger.response(response_code=201,
-                      description='Unconfigure endpoint for Telemetry Report')
+                      description='Remove Telemetry Report endpoint config')
     @swagger.reqparser(name='TelemRptParser', parser=parser)
     def delete(self):
         logger.info('Deactivating telemetry report')
@@ -356,7 +357,7 @@ class TelemetryReportSampling(Resource):
                                   'Telemetry Report')
     @swagger.reqparser(name='TelemRptSampleParser', parser=parser)
     def post(self):
-        logger.info('Setting Telemetry report sampling value')
+        logger.info('Set Telemetry report sampling value')
         args = self.parser.parse_args()
 
         logger.info('Attack args - [%s]', args)


### PR DESCRIPTION
#### What does this PR do?
Fixes #17 
Adds the usage of the Python package flask-restful-swagger-3 so now the REST APIs will be published to http:{controller_ip}:9998/api/doc/swagger.json
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
Access the swagger info from the controller public IP on a browser. See complete URL above.
#### Any background context you want to provide?
This should reduce the MD we will need to write later.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? This one actually helps with our overall doc issues
- Does this add new dependencies? Python - flask-restful-swagger-3 library
- Have you added unit or functional tests for this PR? no
