### PR TITLE
Split the startup routine of snaps-hcp to avoid the 3 min sleep

### DIFF
--- a/playbooks/ae/conf_ae_elk.yml
+++ b/playbooks/ae/conf_ae_elk.yml
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- hosts: ae
+  gather_facts: no
+  tasks:
+    - name: "Validate if a DNS tps.sdn.org is present in /etc/hosts file"
+      become: yes
+      tags: sdnDnsName
+      lineinfile:
+        path: /etc/hosts
+        regexp: "tps.sdn.org"
+        line: "tps.sdn.org {{ sdn_ip }}"
+        state: present
+        backup: yes
+      register: sdnDnsNameOut
+
+    - name: POST call to create Index Pattern
+      uri:
+        url: "http://localhost:5601/api/saved_objects/index-pattern/packets-*"
+        method: POST
+        headers:
+          kbn-xsrf: "true"
+          Content-Type: "application/json"
+        return_content: yes
+        status_code: 200
+        body: "{{ lookup('file','./templates/index_pattern_request_body.json') }}"
+        body_format: json
+      register: index_pattern_response

--- a/playbooks/ae/setup_ae_tcp_pipeline.yml
+++ b/playbooks/ae/setup_ae_tcp_pipeline.yml
@@ -15,8 +15,6 @@
 
 - hosts: ae
   gather_facts: no
-  vars:
-    - CENTOS_HOME: "/home/centos"
   tasks:
     - name: POST call to create TCP data mapping template for incoming data in Elasticsearch
       uri:

--- a/playbooks/ae/setup_ae_udp_pipeline.yml
+++ b/playbooks/ae/setup_ae_udp_pipeline.yml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #Import playbook
-- import_playbook: setup_ae_elk.yml
+- import_playbook: conf_ae_elk.yml
 
 - hosts: ae
   gather_facts: no

--- a/playbooks/ae/setup_ae_udp_pipeline.yml
+++ b/playbooks/ae/setup_ae_udp_pipeline.yml
@@ -15,8 +15,6 @@
 
 - hosts: ae
   gather_facts: no
-  vars:
-    - CENTOS_HOME: "/home/centos"
   tasks:
     - name: POST call to create data mapping template for incoming data in Elasticsearch
       uri:

--- a/playbooks/ae/start_ae_elk.yml
+++ b/playbooks/ae/start_ae_elk.yml
@@ -10,11 +10,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+---
 - hosts: ae
   gather_facts: no
   vars:
-    - CENTOS_HOME: "/home/centos"
+    kibana_wait: "{{ wait_for_kibana | default(180) }}"
   tasks:
     - name: "Start Elasticsearch service"
       become: yes
@@ -35,33 +35,6 @@
         port: 5601
         timeout: 600
 
-    - name: Service check sleep 180 seconds to help Kibana service be ready
-      tags: sleep180
-      wait_for:
-        delay: 180
-        timeout: 0
-
-    - name: "Validate if a DNS tps.sdn.org is present in /etc/hosts file"
-      become: yes
-      tags: sdnDnsName
-      lineinfile:
-        path: /etc/hosts
-        regexp: "tps.sdn.org"
-        line: "tps.sdn.org {{sdn_ip}}"
-        state: present
-        backup: yes
-      register: sdnDnsNameOut
-
-
-    - name: POST call to create Index Pattern
-      uri:
-        url: "http://localhost:5601/api/saved_objects/index-pattern/packets-*"
-        method: POST
-        headers:
-          kbn-xsrf: "true"
-          Content-Type: "application/json"
-        return_content: yes
-        status_code: 200
-        body: "{{ lookup('file','./templates/index_pattern_request_body.json') }}"
-        body_format: json
-      register: index_pattern_response
+    - name: Wait for kibana
+      pause:
+        seconds: "{{ kibana_wait }}"

--- a/playbooks/scenarios/lab_trial/restart_services.yml
+++ b/playbooks/scenarios/lab_trial/restart_services.yml
@@ -64,7 +64,7 @@
   gather_facts: no
   become: yes
   tasks:
-    - name: Restart tps-tofino-ae with state {{ ae_state | default('restarted') }}
+    - name: Restart tps-tofino-ae with state {{ ae_state | default('stopped') }}
       systemd:
         name: tps-tofino-ae
-        state: "{{ ae_state | default('restarted') }}"
+        state: "{{ ae_state | default('stopped') }}"

--- a/playbooks/tofino/setup_nodes-lab_trial.yml
+++ b/playbooks/tofino/setup_nodes-lab_trial.yml
@@ -31,6 +31,13 @@
   vars:
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
 
+# Startup ElasticSearch and Kibana
+#   note: if done after switch startup the wait value needs to be 180 for taking
+#   in configuration
+- import_playbook: ../ae/start_ae_elk.yml
+  vars:
+    wait_for_kibana: 0
+
 # TODO/FIXME - Call setup_tofino_switch playbook so it can run in parallel
 # Start tofino-model and tofino-switchd on the aggregate switch
 - import_playbook: setup_tofino_switch.yml
@@ -52,7 +59,7 @@
     scenario_name: full
     local_srvc_script_tmplt_file: "{{ orch_trans_sec_dir }}/playbooks/general/templates/sdn_controller.sh.j2"
     port_to_wait: "{{ sdn_port }}"
-    wait_timeout: 30
+    wait_timeout: 60
     load_p4: False
 
 # Start AE


### PR DESCRIPTION
#### What does this PR do?
Fixes #341 
Splits the startup of snaps-hcp on the AE machine to avoid a 3 min sleep period
Increased wait time for tps-tofino-sdn from 30 to 60 seconds
Defaulting tps-tofino-ae service to 'stopped'
#### Do you have any concerns with this PR?
Only that I didn't screw up the steps or timing of performing them.
#### How can the reviewer verify this PR?
CI currently will not fail as we do not have any automated tests around snaps-hcp at this time. @akadam, can you ensure things are working as expected?
#### Any background context you want to provide?
Breaking out the snaps-hcp tasks may enable us to more readily reuse some of these tasks.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
