### PR TITLE
Configure drop report frequency and fix AE endpoint

### DIFF
--- a/bin/sdn_controller.py
+++ b/bin/sdn_controller.py
@@ -51,6 +51,12 @@ def get_args():
     parser.add_argument('-s', '--switch-config-dir', dest='switch_config_dir',
                         help='Direction with Switch configurations',
                         required=True)
+    parser.add_argument('-a', '--ae-ip', dest='ae_ip',
+                        help='The IP of the machine to send drop reports',
+                        required=False)
+    parser.add_argument('-drf', '--drop-rpt-freq', dest='drop_rpt_freq',
+                        help='The number of seconds between drop reports',
+                        required=False, default=10, type=int)
     parser.add_argument('-dh', '--debug-host', dest='debug_host',
                         help='remote debugging host IP')
     parser.add_argument('-dp', '--debug-port', dest='debug_port', default=5678,
@@ -140,7 +146,8 @@ def main():
     DdosSdnController(
         topo=topo,
         controllers=controllers,
-        http_server_port=args.http_server_port).start()
+        http_server_port=args.http_server_port,
+        ae_ip_str=args.ae_ip).start()
 
 
 if __name__ == '__main__':

--- a/playbooks/general/templates/sdn_controller.sh.j2
+++ b/playbooks/general/templates/sdn_controller.sh.j2
@@ -19,6 +19,8 @@
 -f {{ log_dir }}/sdn.log \
 -ld {{ log_dir }} \
 -s {{ remote_scripts_dir }}/p4 \
+-a {{ ae_ip }} \
+-drf 10 \
 -p {{ p4_platform }} \
 -hsp {{ sdn_port }} \
 -lp {{ load_p4 }} \

--- a/playbooks/scenarios/lab_trial/drop-rpt.yml
+++ b/playbooks/scenarios/lab_trial/drop-rpt.yml
@@ -1,0 +1,46 @@
+# Copyright (c) 2019 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Refresh lab_trial environment config
+- import_playbook: restart.yml
+  vars:
+    ae_state: restarted
+
+# Basic Drop Report scenario for the lab trial
+- import_playbook: drop_report.yml
+  vars:
+    send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
+    ip_version: "{{ scenario_send_ip_version | default(4) }}"
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    switch: "{{ topo_dict.switches.aggregate }}"
+    switch2: "{{ topo_dict.switches.core }}"
+    send_host: host1
+    rec_host: inet
+    drop_host: ae
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+    drop_receiver: "{{ topo_dict.hosts[drop_host] }}"
+    send_port: 4321
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
+    drop_rpt_intf: eth0
+    dst_mac: "{{ receiver.mac }}"
+    attack:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"
+      body:
+        src_mac: "{{ sender.mac }}"
+        dst_ip: "{% if ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
+        dst_port: "{{ send_port }}"
+      ok_status: 201

--- a/playbooks/scenarios/lab_trial/drop_report.yml
+++ b/playbooks/scenarios/lab_trial/drop_report.yml
@@ -1,0 +1,52 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Start packet mitigation
+- hosts: controller
+  gather_facts: no
+  tasks:
+    - name: Start mitigation with body {{ attack.body }} to {{ attack.url }}
+      uri:
+        url: "{{ attack.url }}"
+        method: POST
+        body_format: "{{ attack.body_format | default('json') }}"
+        body: "{{ attack.body }}"
+        status_code: "{{ attack.ok_status | default('200') }}"
+
+# Sending UDP packets expect none to be received
+- import_playbook: ../test_cases/send_receive.yml
+  vars:
+    int_hops: "{{ sr2_rec_int_hops | default(0) }}"
+    receiver_log_filename: "drop_rpt-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}-2.out"
+    sender_log_filename: "drop_rpt-{{ send_protocol }}-ip-{{ ip_version }}-ih-{{ int_hops }}-2.out"
+    send_port: "{{ send_port }}"
+    send_src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 3) }}"
+    send_loops: 2
+    send_loop_delay: 10
+    send_packet_count: 150
+    min_received_packet_count: 0
+    max_received_packet_count: 0
+
+## Stop packet mitigation
+#- hosts: controller
+#  gather_facts: no
+#  tasks:
+#    - name: Stop mitigation with body {{ attack.body }} to {{ attack.url }}
+#      uri:
+#        url: "{{ attack.url }}"
+#        method: DELETE
+#        body_format: "{{ attack.body_format | default('json') }}"
+#        body: "{{ attack.body }}"
+#        status_code: "{{ attack.ok_status | default('200') }}"

--- a/trans_sec/controller/core_controller.py
+++ b/trans_sec/controller/core_controller.py
@@ -58,11 +58,6 @@ class CoreController(AbstractController):
     def __get_core_switch(self):
         return self.switches[0]
 
-    def get_ae_ip(self):
-        core_switch = self.__get_core_switch()
-        if core_switch:
-            return core_switch.read_ae_ip()
-
     def setup_telem_rpt(self, **kwargs):
         for switch in self.switches:
             if switch.mac == kwargs['switch_mac']:


### PR DESCRIPTION
#### What does this PR do?
Fixes #292 - Thread stop was already fixed but made the interval value configurable.
While looking at Ticket 284 for validating the drop reports, I found a bug where the reports were not getting generated and the AE IP value was incorrect so that was fixed as well.
Also made the changes to receive_packets.py to parse Drop Reports and log their contents.
#### Do you have any concerns with this PR?
Only that I wasn't able to address 284 as I wanted to make sure @akadam will have this functionality while she works on parsing the drop report
#### How can the reviewer verify this PR?
Play around with the SDN new -drf option to see if one can change from the default frequency of 10 seconds
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? not at this time
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? TBD while addressing 284
