### PR TITLE
Added data inspection test that ingress INT into aggregate_tna.p4

### DIFF
--- a/playbooks/scenarios/aggregate/data-inspection.yml
+++ b/playbooks/scenarios/aggregate/data-inspection.yml
@@ -42,3 +42,36 @@
           device_mac: "{{ sender.mac }}"
         ok_status: 201
     sr1_rec_int_hops: 1
+
+- import_playbook: ../single_switch/data_inspection_basic.yml
+  vars:
+    send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
+    ip_version: "{{ scenario_send_ip_version | default(4) }}"
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    switch: "{{ topo_dict.switches.aggregate }}"
+    send_host: host1
+    rec_host: host2
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
+    dst_mac: "{{ receiver['mac'] }}"
+    ws_calls:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataForward"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          dst_mac: "{{ receiver.mac }}"
+          output_port: "{{ switch.tunnels[2].switch_port }}"
+        ok_status: 201
+    data_inspections:
+      - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
+        body:
+          device_id: "{{ switch.id }}"
+          switch_mac: "{{ switch.mac }}"
+          device_mac: "{{ sender.mac }}"
+        ok_status: 201
+    sr1_data_inspection_int:
+      - switch_id: 999
+        orig_mac: "{{ sender.mac }}"
+    sr1_rec_int_hops: 2


### PR DESCRIPTION
#### What does this PR do?
Fixes #251

Adds a new test case to data inspection where the ingress packets are INT with a single hop and egress with an additional switch_id value
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
Ensure CI hasn't failed
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? That was the point
