### PR TITLE
Expanding data-drop tests to validate multiple reports

### DIFF
--- a/playbooks/scenarios/general/drop_report_simple.yml
+++ b/playbooks/scenarios/general/drop_report_simple.yml
@@ -57,10 +57,6 @@
     protocol: "{{ send_protocol | default('UDP') }}"
     receiver_log_file: "{{ log_dir }}/dr-ip-{{ ip_ver }}-proto-{{ protocol }}.log"
   tasks:
-    - name: Wait 20 seconds for the next 2 Drop Report iterations
-      pause:
-        seconds: 20
-
     - name: Create receiver log directory {{ log_dir }}
       file:
         path: "{{ log_dir }}"
@@ -81,19 +77,19 @@
         receive_cmd: >
           {{ trans_sec_dir }}/trans_sec/device_software/receive_packets.py
           -i {{ receiver_intf }} -f {{ receiver_log_file }} -d {{ receive_timeout }} -dr {{ send_ports | length }}
-        register: receive_out
 
-    - name: Receive and log packets with {{ receive_cmd }}
+    - name: Receive Drop Report for {{ send_ports }} with {{ receive_cmd }}
       command: "{{ receive_cmd }}"
       register: receive_out
       changed_when: receive_out is not failed
-
-    - name: Display the receive stdout
-      debug:
-        var: receive_out.stdout
+      retries: 3
+      delay: 10
+      until: receive_out.stdout | length > 5 and receive_out.stdout | from_json | length == send_ports | length
 
     - name: Validate each drop report
       include_tasks: drop_report_validation.yml
+      vars:
+        drop_stats: "{{ receive_out.stdout }}"
       with_items: "{{ send_ports }}"
 
 # Stop packet mitigation

--- a/playbooks/scenarios/general/drop_report_simple.yml
+++ b/playbooks/scenarios/general/drop_report_simple.yml
@@ -24,9 +24,10 @@
         body_format: "{{ attack.body_format | default('json') }}"
         body:
           src_mac: "{{ sender.mac }}"
-          dst_ip: "{% if ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
-          dst_port: "{{ send_port }}"
+          dst_ip: "{% if ip_version | int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
+          dst_port: "{{ item | int }}"
         status_code: 201
+      with_items: "{{ send_ports }}"
 
 # Generate packets from the sender
 - hosts: "{{ send_host }}"
@@ -42,42 +43,8 @@
     receiver_mac: "{{ receiver.mac }}"
     src_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 1) }}"
   tasks:
-    - debug:
-        msg: "Generating packets"
-
-    - name: Create sender log directory {{ log_dir }}
-      file:
-        path: "{{ log_dir }}"
-        state: directory
-
-    - name: Create sender log file {{ sender_log_file }}
-      file:
-        path: "{{ sender_log_file }}"
-        state: touch
-
-    - name: Create send command
-      set_fact:
-        send_cmd: >-
-          {{ trans_sec_dir }}/trans_sec/device_software/send_packets.py
-          -z {{ sender_intf }}
-          -f {{ sender_log_file }}
-          -sp {{ src_port }} -p {{ send_port }}
-          -r {{ receiver_ip }}
-          -m '{{ send_msg }}'
-          -pr {{ send_protocol }}
-          -c {{ send_packet_count }}
-          -i 0.005
-
-    - name: Add known {{ receiver_mac }} to send_packets.py call
-      set_fact:
-        send_cmd: "{{ send_cmd }} -s {{ receiver_mac }}"
-      when: arp_discovery is not defined or not arp_discovery|bool
-
-    - name: Sending packets with command {{ send_cmd }}
-      command: "{{ send_cmd }}"
-      register: cmd_out
-      changed_when: cmd_out is not failed
-      async: 30
+    - include_tasks: drop_rpt_pkt_tasks.yml
+      with_items: "{{ send_ports }}"
 
 # Listen and wait for Drop report
 - hosts: ae
@@ -90,8 +57,9 @@
     protocol: "{{ send_protocol | default('UDP') }}"
     receiver_log_file: "{{ log_dir }}/dr-ip-{{ ip_ver }}-proto-{{ protocol }}.log"
   tasks:
-    - debug:
-        msg: "Wait for drop report for up to {{ receive_timeout }} seconds"
+    - name: Wait 20 seconds for the next 2 Drop Report iterations
+      pause:
+        seconds: 20
 
     - name: Create receiver log directory {{ log_dir }}
       file:
@@ -112,7 +80,7 @@
       set_fact:
         receive_cmd: >
           {{ trans_sec_dir }}/trans_sec/device_software/receive_packets.py
-          -i {{ receiver_intf }} -f {{ receiver_log_file }} -d {{ receive_timeout }} -dr True
+          -i {{ receiver_intf }} -f {{ receiver_log_file }} -d {{ receive_timeout }} -dr {{ send_ports | length }}
         register: receive_out
 
     - name: Receive and log packets with {{ receive_cmd }}
@@ -124,36 +92,9 @@
       debug:
         var: receive_out.stdout
 
-    - name: Get count & hash from stdout
-      set_fact:
-        drop_stats: "{{ receive_out.stdout }}"
-        expected_str: "{{ sender.mac }}|{{ send_port }}|{{ receiver.ip if ip_ver == '4' else '0.0.0.0' }}|{{ receiver.ipv6 | ipaddr if ip_ver == '6' else '::' }}"
-
-    - name: Show string to hash
-      debug:
-        var: expected_str
-
-    - name: Calculate hash string
-      set_fact:
-        hash_str: "{{ expected_str | hash('sha256') }}"
-
-    - name: Get the first 16 bytes
-      set_fact:
-        hash_half_str: "{{ hash_str[:16] }}"
-
-    - name: Convert into int
-      set_fact:
-        hash_val: "{{ hash_half_str | int(base=16) }}"
-
-    - name: Fail when actual hash {{ drop_stats.key_hash }} != expected hash {{ hash_val }}
-      fail:
-        msg: "{{ drop_stats.key_hash }} != {{ hash_val }}"
-      when: drop_stats.key_hash is not defined or drop_stats.key_hash | int != hash_val | int
-
-    - name: Fail when {{ drop_stats.drop_count }} != {{ send_packet_count }}
-      fail:
-        msg: "{{ drop_stats.drop_count }} != {{ send_packet_count }}"
-      when: drop_stats.drop_count is not defined or drop_stats.drop_count != send_packet_count
+    - name: Validate each drop report
+      include_tasks: drop_report_validation.yml
+      with_items: "{{ send_ports }}"
 
 # Stop packet mitigation
 - hosts: controller
@@ -167,5 +108,6 @@
         body:
           src_mac: "{{ sender.mac }}"
           dst_ip: "{% if ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
-          dst_port: "{{ send_port }}"
+          dst_port: "{{ item }}"
         status_code: 201
+      with_items: "{{ send_ports }}"

--- a/playbooks/scenarios/general/drop_report_validation.yml
+++ b/playbooks/scenarios/general/drop_report_validation.yml
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+- name: Parse data from stdout
+  set_fact:
+    drop_stats: "{{ receive_out.stdout }}"
+
+- name: Calculate string to hash
+  set_fact:
+    hashing_str: "{{ sender.mac }}|{{ item }}|{{ receiver.ip if ip_ver == '4' else '0.0.0.0' }}|{{ receiver.ipv6 | ipaddr if ip_ver == '6' else '::' }}"
+
+- name: Calculate hash hex string from {{ hashing_str }}
+  set_fact:
+    hash_str: "{{ hashing_str | hash('sha256') }}"
+
+- name: Get the first 16 bytes of {{ hash_str }}
+  set_fact:
+    hash_half_str: "{{ hash_str[:16] }}"
+
+- name: Convert {{ hash_half_str }} into int
+  set_fact:
+    hash_val: "{{ hash_half_str | int(base=16) }}"
+
+- name: Retrieve count from {{ drop_stats }} with key {{ hash_val }}
+  set_fact:
+    this_count: "{{ drop_stats[hash_val] | int }}"
+
+- name: Fail when sent and received counts differ
+  fail:
+    msg: "{{ this_count }} != {{ send_packet_count }}"
+  when: this_count | int != send_packet_count | int

--- a/playbooks/scenarios/general/drop_report_validation.yml
+++ b/playbooks/scenarios/general/drop_report_validation.yml
@@ -13,10 +13,6 @@
 # Simple scenario where packets are sent through 3 devices and only the last
 # one will be demonstrating dropped packets
 ---
-- name: Parse data from stdout
-  set_fact:
-    drop_stats: "{{ receive_out.stdout }}"
-
 - name: Calculate string to hash
   set_fact:
     hashing_str: "{{ sender.mac }}|{{ item }}|{{ receiver.ip if ip_ver == '4' else '0.0.0.0' }}|{{ receiver.ipv6 | ipaddr if ip_ver == '6' else '::' }}"

--- a/playbooks/scenarios/general/drop_rpt_pkt_tasks.yml
+++ b/playbooks/scenarios/general/drop_rpt_pkt_tasks.yml
@@ -1,0 +1,47 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+- name: Create sender log directory {{ log_dir }}
+  file:
+    path: "{{ log_dir }}"
+    state: directory
+
+- name: Create sender log file {{ sender_log_file }}
+  file:
+    path: "{{ sender_log_file }}"
+    state: touch
+
+- name: Create send command
+  set_fact:
+    send_cmd: >-
+      {{ trans_sec_dir }}/trans_sec/device_software/send_packets.py
+      -z {{ sender_intf }}
+      -f {{ sender_log_file }}
+      -sp {{ src_port }} -p {{ item }}
+      -r {{ receiver_ip }}
+      -m '{{ send_msg }}'
+      -pr {{ send_protocol }}
+      -c {{ send_packet_count }}
+      -i 0.005
+
+- name: Add known {{ receiver_mac }} to send_packets.py call
+  set_fact:
+    send_cmd: "{{ send_cmd }} -s {{ receiver_mac }}"
+  when: arp_discovery is not defined or not arp_discovery|bool
+
+- name: Sending packets with command {{ send_cmd }}
+  command: "{{ send_cmd }}"
+  register: cmd_out
+  changed_when: cmd_out is not failed
+  async: 30

--- a/playbooks/scenarios/lab_trial/drop-rpt.yml
+++ b/playbooks/scenarios/lab_trial/drop-rpt.yml
@@ -14,7 +14,7 @@
 # one will be demonstrating dropped packets
 ---
 # Basic Drop Report scenario for the lab trial
-- import_playbook: drop_report_simple.yml
+- import_playbook: ../general/drop_report_simple.yml
   vars:
     send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
     ip_version: "{{ scenario_send_ip_version | default(4) }}"
@@ -24,5 +24,10 @@
     drop_host: ae
     sender: "{{ topo_dict.hosts[send_host] }}"
     receiver: "{{ topo_dict.hosts[rec_host] }}"
-    send_port: "{{ '%s' % range(2000, 10000) | random(seed=now|int + 1) }}"
+    send_ports:
+      - 1234
+      - 3456
+      - 5678
+      - 7890
     send_packet_count: 50
+    arp_discovery: True

--- a/playbooks/tofino/setup_nodes-single_switch.yml
+++ b/playbooks/tofino/setup_nodes-single_switch.yml
@@ -55,5 +55,5 @@
     scenario_name: full
     local_srvc_script_tmplt_file: "{{ orch_trans_sec_dir }}/playbooks/general/templates/sdn_controller.sh.j2"
     port_to_wait: "{{ sdn_port }}"
-    wait_timeout: 30
+    wait_timeout: 60
     load_p4: False


### PR DESCRIPTION
#### What does this PR do?
Fixes #354 
 Ensures that the controller is emitting drop reports for each entry in the data_drop_t table.
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
Ensure CI passes
#### Any background context you want to provide?
The previous drop report tests were only performed with one table entry
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? Improved the existing drop report tests
