### PR TITLE
Simple ae listen and act on drop reports

### DIFF
--- a/bin/start_ae.py
+++ b/bin/start_ae.py
@@ -102,6 +102,8 @@ def main():
         logger.info('LoggerAE instantiated')
         ae = IntLoggerAE(http_session)
 
+    logger.info('Begin sniffing for INT on [%s] and Drop Reports on [%s]',
+                args.interface, args.drop_interface)
     ae.start_sniffing(args.interface, args.drop_interface)
     sys.stdout.flush()
 

--- a/playbooks/scenarios/lab_trial/all-pkt-flood.yml
+++ b/playbooks/scenarios/lab_trial/all-pkt-flood.yml
@@ -19,57 +19,25 @@
     ae_state: restarted
 
 # Data Inspection scenarios for UDP and IPv4
-- import_playbook: data-inspection.yml
+- import_playbook: pkt-flood.yml
   vars:
-    di_log_prfx: di-ae-dd
     scenario_send_protocol: UDP
     scenario_send_ip_version: 4
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 15
-    arp_discovery: True
-    sample_rate: 0
-    ae_state: restarted
 
-# Data Inspection scenarios for UDP and IPv6 with AE for testing dropping packets
-- import_playbook: data-inspection.yml
+# Data Inspection scenarios for UDP and IPv6
+- import_playbook: pkt-flood.yml
   vars:
-    di_log_prfx: di-ae-dd
     scenario_send_protocol: UDP
     scenario_send_ip_version: 6
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 15
-    arp_discovery: True
-    sample_rate: 0
-    ae_state: restarted
 
-# Data Inspection scenarios for TCP and IPv4 with AE for testing dropping packets
-- import_playbook: data-inspection.yml
+# Data Inspection scenarios for TCP and IPv4
+- import_playbook: pkt-flood.yml
   vars:
-    di_log_prfx: di-ae-dd
     scenario_send_protocol: TCP
     scenario_send_ip_version: 4
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 15
-    arp_discovery: True
-    sample_rate: 0
-    ae_state: restarted
 
-# Data Inspection scenarios for TCP and IPv6 with AE for testing dropping packets
-- import_playbook: data-inspection.yml
+# Data Inspection scenarios for TCP and IPv6
+- import_playbook: pkt-flood.yml
   vars:
-    di_log_prfx: di-ae-dd
     scenario_send_protocol: TCP
     scenario_send_ip_version: 6
-    di_send_packet_count: 150
-    di_min_rec_packet_count: 99
-    di_send_loops: 2
-    di_send_loop_delay: 15
-    arp_discovery: True
-    sample_rate: 0
-    ae_state: restarted

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -17,11 +17,15 @@
 - hosts: ae
   gather_facts: no
   become: yes
+  vars:
+    ae_srvc_state: "{{ ae_state }}"
+    exe_systemd: "{% if ae_state == 'none' %}False{% else %}True{% endif %}"
   tasks:
     - name: Restart tps-tofino-ae with state {{ ae_state | default('stopped') }}
       systemd:
         name: tps-tofino-ae
-        state: "{{ ae_state | default('stopped') }}"
+        state: "{{ ae_srvc_state | default('stopped') }}"
+      when: exe_systemd | bool
 
 # Call POST on all WS calls
 - hosts: controller
@@ -35,6 +39,7 @@
         body:
           sample: "{{ sample_rate }}"
         status_code: 201
+      when: sample_rate is defined
 
 # Sending packets expect all to be received with configured INT hops sr1_rec_int_hops
 - import_playbook: ../test_cases/send_receive.yml
@@ -50,10 +55,3 @@
     inspection_data: "{{ sr1_data_inspection_int | default(None) }}"
     send_loops: "{{ di_send_loops | default(1) }}"
     send_loop_delay: "{{ di_send_loop_delay | default(5) }}"
-    cleanup_rest_call:
-      url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"
-      body:
-        src_mac: "{{ sender.mac }}"
-        dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
-        dst_port: "{{ send_port }}"
-      ok_status: 201

--- a/playbooks/scenarios/lab_trial/data_inspection_basic.yml
+++ b/playbooks/scenarios/lab_trial/data_inspection_basic.yml
@@ -18,13 +18,13 @@
   gather_facts: no
   become: yes
   vars:
-    ae_srvc_state: "{{ ae_state }}"
-    exe_systemd: "{% if ae_state == 'none' %}False{% else %}True{% endif %}"
+    ae_srvc_state: "{{ ae_state | default('stopped') }}"
+    exe_systemd: "{% if ae_srvc_state == 'none' %}False{% else %}True{% endif %}"
   tasks:
-    - name: Restart tps-tofino-ae with state {{ ae_state | default('stopped') }}
+    - name: Restart tps-tofino-ae with state {{ ae_srvc_state }}
       systemd:
         name: tps-tofino-ae
-        state: "{{ ae_srvc_state | default('stopped') }}"
+        state: "{{ ae_srvc_state }}"
       when: exe_systemd | bool
 
 # Call POST on all WS calls

--- a/playbooks/scenarios/lab_trial/pkt-flood.yml
+++ b/playbooks/scenarios/lab_trial/pkt-flood.yml
@@ -1,0 +1,78 @@
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Simple scenario where packets are sent through 3 devices and only the last
+# one will be demonstrating dropped packets
+---
+# Basic Data Inspection scenario - receiving packets on inet host
+- import_playbook: data_inspection_basic.yml
+  vars:
+    di_log_prfx: pkt-flood-1
+    send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
+    ip_version: "{{ scenario_send_ip_version | default(4) }}"
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_send_loops: 2
+    di_send_loop_delay: 15
+    arp_discovery: True
+    ae_state: restarted
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    switch: "{{ topo_dict.switches.aggregate }}"
+    switch2: "{{ topo_dict.switches.core }}"
+    send_host: host1
+    rec_host: inet
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
+    dst_mac: "{{ receiver['mac'] }}"
+    expected_rate: 0
+
+# Start packet mitigation
+- hosts: controller
+  gather_facts: no
+  vars:
+    wait_time: "{{ release_wait | default(45) }}"
+  tasks:
+    - name: Wait {{ wait_time }} seconds to un-mitigate
+      pause:
+        seconds: "{{ wait_time }}"
+
+- import_playbook: data_inspection_basic.yml
+  vars:
+    di_log_prfx: pkt-flood-2
+    send_protocol: "{{ scenario_send_protocol | default('UDP') }}"
+    ip_version: "{{ scenario_send_ip_version | default(4) }}"
+    di_send_packet_count: 150
+    di_min_rec_packet_count: 99
+    di_send_loops: 2
+    di_send_loop_delay: 15
+    arp_discovery: True
+    ae_state: none
+    topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
+    switch: "{{ topo_dict.switches.aggregate }}"
+    switch2: "{{ topo_dict.switches.core }}"
+    send_host: host1
+    rec_host: inet
+    sender: "{{ topo_dict.hosts[send_host] }}"
+    receiver: "{{ topo_dict.hosts[rec_host] }}"
+    sender_intf_name: "{{ sender.intf_name }}"
+    rec_intf_name: "{{ receiver.intf_name }}"
+    dst_mac: "{{ receiver['mac'] }}"
+    expected_rate: 0
+    cleanup_rest_call:
+      url: "http://{{ sdn_ip }}:{{ sdn_port }}/aggAttack"
+      body:
+        src_mac: "{{ sender.mac }}"
+        dst_ip: "{% if scenario_send_ip_version|int == 4 %}{{ receiver.ip }}{% else %}{{ receiver.ipv6 }}{% endif %}"
+        dst_port: "{{ send_port }}"
+      ok_status: 201

--- a/playbooks/scenarios/lab_trial/restart_services.yml
+++ b/playbooks/scenarios/lab_trial/restart_services.yml
@@ -68,11 +68,11 @@
   become: yes
   vars:
     ae_srvc_state: "{{ ae_state | default('stopped') }}"
-    exe_systemd: "{% if ae_state == 'none' %}False{% else %}True{% endif %}"
+    exe_systemd: "{% if ae_srvc_state == 'none' %}False{% else %}True{% endif %}"
   tasks:
     - debug:
         var: exe_systemd
-    - name: Restart tps-tofino-ae with state {{ ae_state | default('stopped') }}
+    - name: Restart tps-tofino-ae with state {{ ae_srvc_state }}
       systemd:
         name: tps-tofino-ae
         state: "{{ ae_srvc_state }}"

--- a/playbooks/scenarios/lab_trial/restart_services.yml
+++ b/playbooks/scenarios/lab_trial/restart_services.yml
@@ -21,6 +21,8 @@
   become: yes
   vars:
     restart_switch: "{{ switch_restart | default(True) }}"
+    run_on_hw: "{{ from_hw | default(False) | bool }}"
+    restart_model: "{{ not run_on_hw|bool }}"
   tasks:
     - block:
       - name: Stop tps-tofino-switchd
@@ -32,13 +34,13 @@
         systemd:
           name: tps-tofino-model
           state: restarted
-        when: not from_hw | bool
+        when: restart_model
 
       - name: Restart tps-tofino-switchd
         systemd:
           name: tps-tofino-switchd
           state: restarted
-      when: restart_switch | bool
+      when: restart_switch
 
     - name: Wait for tps-tofino-switchd to open port
       wait_for:
@@ -64,8 +66,14 @@
 - hosts: ae
   gather_facts: no
   become: yes
+  vars:
+    ae_srvc_state: "{{ ae_state | default('stopped') }}"
+    exe_systemd: "{% if ae_state == 'none' %}False{% else %}True{% endif %}"
   tasks:
+    - debug:
+        var: exe_systemd
     - name: Restart tps-tofino-ae with state {{ ae_state | default('stopped') }}
       systemd:
         name: tps-tofino-ae
-        state: "{{ ae_state | default('stopped') }}"
+        state: "{{ ae_srvc_state }}"
+      when: exe_systemd | bool

--- a/trans_sec/utils/http_session.py
+++ b/trans_sec/utils/http_session.py
@@ -87,14 +87,13 @@ class HttpSession:
                 raise AlreadyExistsError(
                     body['Addr'], str(temp['Messages'][0]))
 
-    def delete(self, resource, key):
-        logger.info('DELETE resource [%s] with key [%s]', resource, key)
+    def delete(self, resource, body):
+        logger.info('DELETE resource [%s] with key [%s]', resource, body)
         if not self.is_authorized():
             self.authorize()
         headers = {'Authorization': 'Bearer ' + self.token}
-        actual_resource = resource + '/' + key
-        r = requests.delete(self.url + '/' + actual_resource,
-                            headers=headers, verify=False)
+        r = requests.delete(self.url + '/' + resource,
+                            headers=headers, json=body, verify=False)
         if r.status_code == 200:
             logger.info('DELETE return value - [%s]', r.json())
             return r.json()


### PR DESCRIPTION
#### What does this PR do?
Fixes #351 
Adds the ability for the SimpleAE to ingest drop reports and enable it to tell the controller when the attack has ceased.
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
ensure CI passes
#### Any background context you want to provide?
With drop reports being properly created, we need to ensure we can act on these packets. The rules for the SimpleAE are rudimentary. When the pre-configured number of drop reports (default 3) are received without any other packets from the device to a given destination, a DELETE RESTful call is made to the same endpoint the POST was made with the same arguments.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? eventually if/when we document the SimpleAE
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? Expanded the existing pkt-flood tests to ensure packets can flow again as well as get mitigated a second time.
