### PR TITLE
Created config file for the SimpleAE to allow for easier re-config

### DIFF
--- a/automation/p4/tofino/scenarios.tf
+++ b/automation/p4/tofino/scenarios.tf
@@ -18,7 +18,7 @@ resource "null_resource" "transparent-security-run-scenario-tests" {
   provisioner "remote-exec" {
     inline = [
       "sudo pip install ansible",
-      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_scenario_pb_dir}/${var.scenario_name}/${var.test_case}.yml --extra-vars='from_hw=${var.from_hw}'",
+      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_scenario_pb_dir}/${var.scenario_name}/${var.test_case}.yml",
     ]
   }
 

--- a/automation/p4/tofino/setup.tf
+++ b/automation/p4/tofino/setup.tf
@@ -205,7 +205,7 @@ resource "null_resource" "tps-tofino-setup-nodes" {
   provisioner "remote-exec" {
     inline = [
       "sudo pip install ansible",
-      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_pb_dir}/tofino/${local.setup_pb} --extra-vars='scenario_name=${var.scenario_name} from_hw=${var.from_hw}'"
+      "${var.ANSIBLE_CMD} -i ${var.remote_inventory_file} ${var.remote_pb_dir}/tofino/${local.setup_pb} --extra-vars='scenario_name=${var.scenario_name}'"
     ]
   }
 

--- a/automation/p4/tofino/variables.tf
+++ b/automation/p4/tofino/variables.tf
@@ -75,7 +75,6 @@ variable "ae_monitor_intf" {default = "core-tun"}
 variable "ae_lab_intf" {default = "core-tun1"}
 variable "clone_egress_port" {default = "3"}
 variable "p4_arch" {default = "tna"}
-variable "from_hw" {default = "False"}
 
 variable "setup_nodes_pb" {default = "setup_nodes.yml"}
 variable "scenario_name" {default = "full"}

--- a/playbooks/general/start_service.yml
+++ b/playbooks/general/start_service.yml
@@ -25,7 +25,6 @@
     srvc_status: "{{ service_status_running | default('true') }}"
     start_srvc: "{{ start_service | default(True) }}"
     topo_dict: "{{ lookup('file','{{ topo_file_loc }}') | from_yaml }}"
-
   tasks:
     - name: Start service block when {{ start_srvc }} is true
       block:
@@ -49,7 +48,7 @@
         template:
           src: "{{ additional_tmplt_file }}"
           dest: "{{ additional_tmplt_out_file }}"
-        when: additional_tmplt_file is defined
+        when: additional_tmplt_file is defined and additional_tmplt_out_file is defined
 
       - name: Copy {{ srvc_name }} Service File to /etc/systemd/system/{{ srvc_name }}.service
         template:

--- a/playbooks/general/templates/ae_service.yaml.j2
+++ b/playbooks/general/templates/ae_service.yaml.j2
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-
-# Copyright (c) 2019 Cable Television Laboratories, Inc.
+# Copyright (c) 2020 Cable Television Laboratories, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,9 +10,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Runs the Analytics Engine
-{{ trans_sec_dir }}/bin/start_ae.py \
--l {{ log_level }} \
--f {{ log_dir }}/{{ service_name }}.log \
--c {{ additional_tmplt_out_file }}
+---
+sdn_url: {{ sdn_url }}
+monitor_intf: {{ monitor_intf }}
+drop_rpt_intf: {{ ae_ip_intf }}
+drop_count: {{ drop_count | default(3) }}
+service_type: {{ srvc_type }}
+packet_count: {{ packet_count | default(100) }}
+sample_interval: {{ sample_interval | default(60) }}
+sdn_attack_ctx: {{ sdn_attack_context }}

--- a/playbooks/tofino/setup_nodes-lab_trial.yml
+++ b/playbooks/tofino/setup_nodes-lab_trial.yml
@@ -76,6 +76,8 @@
     host_val: ae
     service_name: tps-tofino-ae
     local_srvc_script_tmplt_file: "{{ orch_trans_sec_dir }}/playbooks/general/templates/ae_service.sh.j2"
+    additional_tmplt_file: "{{ orch_trans_sec_dir }}/playbooks/general/templates/ae_service.yaml.j2"
+    additional_tmplt_out_file: "{{ remote_scripts_dir }}/ae_service.yaml"
     srvc_type: SIMPLE
     sdn_url: "http://{{ sdn_ip }}:{{ sdn_port }}"
     monitor_intf: "{{ ae_monitor_intf }}"

--- a/playbooks/tofino/setup_tofino_switch.yml
+++ b/playbooks/tofino/setup_tofino_switch.yml
@@ -31,7 +31,7 @@
     prog_name: "{{ p4_pkg }}"
     additional_tmplt_file: "{{ trans_sec_dir }}/playbooks/tofino/templates/tofino-model-veth-port-mapping.json.j2"
     additional_tmplt_out_file: "{{ remote_scripts_dir }}/port-mapping.json"
-  when: not from_hw | bool
+  when: not (from_hw | default(False) | bool)
 
 # Start switchd
 - import_playbook: ../general/start_service.yml

--- a/playbooks/tofino/setup_virt_eth.yml
+++ b/playbooks/tofino/setup_virt_eth.yml
@@ -20,7 +20,7 @@
     SDE: "{{ remote_sde_dir }}"
     SDE_INSTALL: "{{ remote_sde_dir }}/install"
   vars:
-    setup_veth: "{{ not from_hw|bool | default(True) }}"
+    setup_veth: "{{ not (from_hw | default(False) | bool) }}"
   tasks:
     - debug:
         var: from_hw

--- a/playbooks/tofino/tunnel/setup_gre_tunnels.yml
+++ b/playbooks/tofino/tunnel/setup_gre_tunnels.yml
@@ -19,7 +19,7 @@
   gather_facts: yes
   become: yes
   vars:
-    setup_tunnels: "{{ not from_hw|bool | default(True) }}"
+    setup_tunnels: "{{ not (from_hw | default(False) | bool) }}"
   tasks:
     - debug:
         var: from_hw

--- a/trans_sec/analytics/oinc.py
+++ b/trans_sec/analytics/oinc.py
@@ -53,8 +53,8 @@ class PacketAnalytics(object):
         self.sniff_stop = threading.Event()
         self.sdn_attack_context = sdn_attack_context
 
-        logger.debug("Started AE with attack call to [%s/%s]",
-                     self.sdn_interface, self.sdn_attack_context)
+        logger.debug("Started AE with attack call to [/%s]",
+                     self.sdn_attack_context)
 
     def start_sniffing(self, iface, drop_iface=None,
                        udp_dport=UDP_TRPT_DST_PORT):
@@ -79,7 +79,6 @@ class PacketAnalytics(object):
 
     def sniff_int(self, iface, udp_port):
         logger.info("INT monitoring iface [%s]", iface)
-
         try:
             sniff(iface=iface,
                   prn=lambda packet: self.handle_packet(packet, udp_port),
@@ -87,9 +86,10 @@ class PacketAnalytics(object):
         except Exception as e:
             logger.error('Unexpected error sniffing for INT Data - [%s]', e)
 
+    # TODO/FIXME - Had issues with sending in a single param function.
+    #  determine how to get rid of the 'foo' param
     def sniff_drop(self, iface, foo=None):
         logger.info("Drop monitoring iface [%s]", iface)
-
         try:
             sniff(iface=iface,
                   prn=lambda packet: self.handle_drop_rpt(packet),


### PR DESCRIPTION
#### What does this PR do?
Fixes #360 
Removed the analytics behavioral configuration values from the start_ae.py input arguments to a configuration file located on the ae host's /etc/transparent-security directory named ae_service.yml. After changing the values and restarting the service, the AE's behavior will change accordingly.
from_hw setup nodes and integration test parameter for lab_trial is now optional
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
Ensure CI passes or run the 'all-pkt-flood' test scenario to ensure the AE is still functioning with its default values as expected.
#### Any background context you want to provide?
While running in the lab_trial, we may need to quickly reconfigure the SimpleAE should we need it.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? eventually
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
