### PR TITLE
reactivated UDP IPv6 pkt-flood tests

### DIFF
--- a/playbooks/scenarios/lab_trial/all-pkt-flood.yml
+++ b/playbooks/scenarios/lab_trial/all-pkt-flood.yml
@@ -16,26 +16,25 @@
 # Refresh lab_trial environment config
 - import_playbook: restart.yml
 
-# Data Inspection scenarios for UDP and IPv4
+# Packet Flood scenarios for UDP and IPv4
 - import_playbook: pkt-flood.yml
   vars:
     scenario_send_protocol: UDP
     scenario_send_ip_version: 4
 
-# TODO: Fix UDPv6 pipeline for detecting and mitigating attack
-# Data Inspection scenarios for UDP and IPv6
-#- import_playbook: pkt-flood.yml
-#  vars:
-#    scenario_send_protocol: UDP
-#    scenario_send_ip_version: 6
+# Packet Flood scenarios for UDP and IPv6
+- import_playbook: pkt-flood.yml
+  vars:
+    scenario_send_protocol: UDP
+    scenario_send_ip_version: 6
 
-# Data Inspection scenarios for TCP and IPv4
+# Packet Flood scenarios for TCP and IPv4
 - import_playbook: pkt-flood.yml
   vars:
     scenario_send_protocol: TCP
     scenario_send_ip_version: 4
 
-# Data Inspection scenarios for TCP and IPv6
+# Packet Flood scenarios for TCP and IPv6
 - import_playbook: pkt-flood.yml
   vars:
     scenario_send_protocol: TCP


### PR DESCRIPTION
#### What does this PR do?
Reactivates the pkt-flood tests for UDP IPv6
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
ensure CI does not fail
#### Any background context you want to provide?
@akadam and I fixed the issue with UDP/6 tests but forgot to reactivate the tests
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? n/a
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? reactivated an existing that was failing
