### PR TITLE
Bug fix when TRPT not configured and added bridge_md for all packets

### DIFF
--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -168,12 +168,6 @@ control TpsAggIngress(
     }
 
     apply {
-        /* Value will be set with the udp_int.dst_port in the parser
-           which would be incorrect in this case */
-        if (hdr.tcp.isValid()) {
-            meta.dst_port = hdr.tcp.dst_port;
-        }
-
         // Basic forwarding and drop logic
         if (data_drop_t.apply().miss) {
             default_port_t.apply();
@@ -423,9 +417,12 @@ control TpsAggEgress(
 
         // TODO/FIXME - see INT 2.1 spec on how to calculate this value
         //hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+        hdr.udp_int.src_port = hdr.tcp.src_port;
 
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
         hdr.udp_int.len = hdr.ipv4.totalLen - IPV4_HDR_BYTES;
+        hdr.ipv4.protocol = TYPE_UDP;
+        hdr.tcp.src_port = hdr.udp_int.src_port;
     }
 
     action insert_udp_int_for_tcp_ipv6() {
@@ -433,9 +430,12 @@ control TpsAggEgress(
 
         // TODO/FIXME - see INT 2.1 spec on how to calculate this value
         //hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+        hdr.udp_int.src_port = hdr.tcp.src_port;
 
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
         hdr.udp_int.len = hdr.ipv6.payload_len;
+        hdr.ipv6.next_hdr_proto = TYPE_UDP;
+        hdr.tcp.src_port = hdr.udp_int.src_port;
     }
 
     apply {

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -406,6 +406,7 @@ control TpsAggEgress(
         hdr.udp.src_port = hdr.udp_int.src_port;
         hdr.udp.dst_port = hdr.udp_int.dst_port;
         hdr.udp.len = hdr.udp_int.len;
+        hdr.udp.cksum = hdr.udp_int.cksum;
         hdr.udp_int.src_port = UDP_INT_SRC_PORT;
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
 
@@ -455,6 +456,7 @@ control TpsAggEgress(
                     }
                 }
             }
+            hdr.udp_int.cksum = 0;
         }
     }
 }
@@ -466,7 +468,23 @@ control TpsAggEgressDeparser(
     in agg_metadata_t meta,
     in egress_intrinsic_metadata_for_deparser_t eg_intr_dprsr_md) {
 
+    Checksum() ipv4_checksum;
+
     apply {
+        hdr.ipv4.hdrChecksum = ipv4_checksum.update({
+            hdr.ipv4.version,
+            hdr.ipv4.ihl,
+            hdr.ipv4.diffserv,
+            hdr.ipv4.totalLen,
+            hdr.ipv4.identification,
+            hdr.ipv4.flags,
+            hdr.ipv4.fragOffset,
+            hdr.ipv4.ttl,
+            hdr.ipv4.protocol,
+            hdr.ipv4.srcAddr,
+            hdr.ipv4.dstAddr
+        });
+
         /* For Standard and INT Packets */
         packet.emit(hdr.ethernet);
         packet.emit(hdr.arp);

--- a/p4/aggregate/aggregate_tna.p4
+++ b/p4/aggregate/aggregate_tna.p4
@@ -407,7 +407,10 @@ control TpsAggEgress(
         hdr.udp.dst_port = hdr.udp_int.dst_port;
         hdr.udp.len = hdr.udp_int.len;
         hdr.udp.cksum = hdr.udp_int.cksum;
-        hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+
+        // TODO/FIXME - see INT 2.1 spec on how to calculate this value
+        //hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
 
         // TODO/FIXME - This value will be incorrect once the gateway with INT has been added into the mix
@@ -417,14 +420,20 @@ control TpsAggEgress(
 
     action insert_udp_int_for_tcp_ipv4() {
         hdr.udp_int.setValid();
-        hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+
+        // TODO/FIXME - see INT 2.1 spec on how to calculate this value
+        //hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
         hdr.udp_int.len = hdr.ipv4.totalLen - IPV4_HDR_BYTES;
     }
 
     action insert_udp_int_for_tcp_ipv6() {
         hdr.udp_int.setValid();
-        hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+
+        // TODO/FIXME - see INT 2.1 spec on how to calculate this value
+        //hdr.udp_int.src_port = UDP_INT_SRC_PORT;
+
         hdr.udp_int.dst_port = UDP_INT_DST_PORT;
         hdr.udp_int.len = hdr.ipv6.payload_len;
     }

--- a/p4/core/core_tna.p4
+++ b/p4/core/core_tna.p4
@@ -455,10 +455,6 @@ control TpsCoreEgress(
                 } else {
                     control_drop();
                 }
-                // TODO/FIXME - This may simply be a parameter when configuring the mirror table
-                /* Ensure packet is no larger than TRPT_MAX_BYTES
-                truncate(TRPT_MAX_BYTES);
-                */
             } else {
                 control_drop();
             }

--- a/p4/core/core_tna.p4
+++ b/p4/core/core_tna.p4
@@ -531,16 +531,6 @@ control TpsCoreEgressDeparser(
                  hdr.trpt_ipv4.srcAddr,
                  hdr.trpt_ipv4.dstAddr});
 
-        hdr.udp_int.cksum = checksum.update(
-                {hdr.udp_int.src_port,
-                 hdr.udp_int.dst_port,
-                 hdr.udp_int.len});
-
-        hdr.trpt_udp.cksum = checksum.update(
-                {hdr.trpt_udp.src_port,
-                 hdr.trpt_udp.dst_port,
-                 hdr.trpt_udp.len});
-
         /* For Telemetry Report Packets */
         packet.emit(hdr.trpt_eth);
         packet.emit(hdr.trpt_ipv4);

--- a/p4/core/core_tna.p4
+++ b/p4/core/core_tna.p4
@@ -351,7 +351,8 @@ control TpsCoreEgress(
         hdr.trpt_hdr.sequence_no = 0;
         hdr.trpt_hdr.sequence_pad = 0;
         hdr.trpt_hdr.sequence_no = hdr.trpt_hdr.sequence_no + 1;
-        hdr.trpt_eth.dst_mac = hdr.ethernet.dst_mac;
+        //hdr.trpt_eth.dst_mac = hdr.ethernet.dst_mac;
+        hdr.trpt_eth.dst_mac = 0xffffffffffff;
         hdr.trpt_eth.src_mac = hdr.ethernet.src_mac;
         hdr.trpt_udp.dst_port = TRPT_INT_DST_PORT;
     }

--- a/p4/core/core_tna.p4
+++ b/p4/core/core_tna.p4
@@ -169,6 +169,9 @@ control TpsCoreIngress(
              */
             if (ig_intr_md.ingress_port == ig_tm_md.ucast_egress_port) {
                 ig_dprsr_md.drop_ctl = TNA_DROP_CTL;
+            } else {
+                hdr.bridge_md.setValid();
+                hdr.bridge_md.pkt_type = PKT_TYPE_NORMAL;
             }
         }
     }
@@ -189,7 +192,7 @@ control TpsCoreIngressDeparser(
 
     apply {
         // Block requried for creating the telemtry report
-        if (ig_dprsr_md.mirror_type == ING_PORT_MIRROR) {
+        if (meta.pkt_type == PKT_TYPE_MIRROR) {
             ing_port_mirror.emit<mirror_h>(
                 meta.mirror_session, {meta.pkt_type});
         }
@@ -221,22 +224,13 @@ parser TpsCoreEgressParser(
 
     state start {
         tofino_parser.apply(packet, eg_intr_md);
-        mirror_h mirror_md = packet.lookahead<mirror_h>();
-        transition select(mirror_md.pkt_type) {
-            PKT_TYPE_MIRROR : parse_mirror_md;
-            default : parse_normal;
-        }
-    }
-
-    state parse_normal {
-        meta.pkt_type = PKT_TYPE_NORMAL;
-        transition parse_ethernet;
+        transition parse_mirror_md;
     }
 
     state parse_mirror_md {
         mirror_h mirror_md;
         packet.extract(mirror_md);
-        meta.pkt_type = PKT_TYPE_MIRROR;
+        meta.pkt_type = mirror_md.pkt_type;
         transition parse_ethernet;
     }
 
@@ -366,8 +360,8 @@ control TpsCoreEgress(
     action set_telem_rpt_in_type_ipv4() {
         // TODO - write tests to test this action
         hdr.trpt_hdr.in_type = TRPT_HDR_IN_TYPE_IPV4;
-        //hdr.trpt_ipv6.payload_len = hdr.ipv4.totalLen + (
-        //    IPV6_HDR_BYTES + UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES + ETH_HDR_BYTES);
+        hdr.trpt_ipv6.payload_len = hdr.ipv4.totalLen + (
+            IPV6_HDR_BYTES + UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES + ETH_HDR_BYTES);
         hdr.trpt_ipv4.totalLen = hdr.ipv4.totalLen + (
             IPV4_HDR_BYTES + UDP_HDR_BYTES + (
                 INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + SWITCH_ID_HDR_BYTES + 6);
@@ -378,8 +372,8 @@ control TpsCoreEgress(
     /* Sets the trpt_eth.in_type for IPv6 */
     action set_telem_rpt_in_type_ipv6() {
         hdr.trpt_hdr.in_type = TRPT_HDR_IN_TYPE_IPV6;
-        //hdr.trpt_ipv6.payload_len = hdr.ipv6.payload_len + (
-        //    IPV6_HDR_BYTES + UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES + ETH_HDR_BYTES);
+        hdr.trpt_ipv6.payload_len = hdr.ipv6.payload_len + (
+            IPV6_HDR_BYTES + UDP_HDR_BYTES + TRPT_HDR_BASE_BYTES + ETH_HDR_BYTES);
         hdr.trpt_ipv4.totalLen = hdr.ipv6.payload_len + (
             IPV4_HDR_BYTES + IPV6_HDR_BYTES + UDP_HDR_BYTES + (
                 INT_SHIM_BASE_SIZE * BYTES_PER_SHIM) + SWITCH_ID_HDR_BYTES + 6);
@@ -449,13 +443,16 @@ control TpsCoreEgress(
                 if (hdr.ipv6.isValid()) {
                     set_telem_rpt_in_type_ipv6();
                 }
-                setup_telemetry_rpt_t.apply();
-                if (hdr.ipv4.isValid()) {
-                    hdr.trpt_hdr.rpt_len = hdr.trpt_hdr.rpt_len + 10;
-                    hdr.ipv4.protocol = hdr.int_shim.next_proto;
-                } else if (hdr.ipv6.isValid()) {
-                    hdr.trpt_hdr.rpt_len = hdr.trpt_hdr.rpt_len + 15;
-                    hdr.ipv6.next_hdr_proto = hdr.int_shim.next_proto;
+                if(setup_telemetry_rpt_t.apply().hit) {
+                    if (hdr.ipv4.isValid()) {
+                        hdr.trpt_hdr.rpt_len = hdr.trpt_hdr.rpt_len + 10;
+                        hdr.ipv4.protocol = hdr.int_shim.next_proto;
+                    } else if (hdr.ipv6.isValid()) {
+                        hdr.trpt_hdr.rpt_len = hdr.trpt_hdr.rpt_len + 15;
+                        hdr.ipv6.next_hdr_proto = hdr.int_shim.next_proto;
+                    }
+                } else {
+                    control_drop();
                 }
                 // TODO/FIXME - This may simply be a parameter when configuring the mirror table
                 /* Ensure packet is no larger than TRPT_MAX_BYTES

--- a/p4/include/tna_mirror.p4
+++ b/p4/include/tna_mirror.p4
@@ -15,7 +15,7 @@
 /* -*- P4_16 -*- */
 
 typedef bit<3> mirror_type_t;
-typedef bit<8> pkt_type_t;
+typedef bit<16> pkt_type_t;
 
 /* Ingress mirroring information */
 const bit<3> ING_PORT_MIRROR = 1;

--- a/p4/include/tps_consts.p4
+++ b/p4/include/tps_consts.p4
@@ -70,8 +70,6 @@ const bit<4> INT_VERSION = 0x2;
 const bit<5> INT_META_LEN = 0x1;
 /* The supported Telemetry Report version */
 const bit<4> TRPT_VERSION = 0x2;
-/* The expected UDP INT header source port value */
-const bit<16> UDP_INT_SRC_PORT = 0x0;
 /* The expected UDP INT header destination port value */
 const bit<16> UDP_INT_DST_PORT = 0x022b;
 /* The expected Telemetry Report UDP destination port value */

--- a/p4/include/tps_headers.p4
+++ b/p4/include/tps_headers.p4
@@ -213,7 +213,7 @@ header telem_rpt_t { /* 10 */
 }
 
 header bridge_md_t {
-    bit<8>  pkt_type;
+    bit<16>  pkt_type;
 }
 
 struct headers {

--- a/p4/include/tps_headers.p4
+++ b/p4/include/tps_headers.p4
@@ -212,7 +212,12 @@ header telem_rpt_t { /* 10 */
     bit<32> var_opt_md;
 }
 
+header bridge_md_t {
+    bit<8>  pkt_type;
+}
+
 struct headers {
+    bridge_md_t       bridge_md;
     ethernet_t        trpt_eth;
     ipv4_t            trpt_ipv4;
     ipv6_t            trpt_ipv6;

--- a/playbooks/scenarios/core/data-inspection.yml
+++ b/playbooks/scenarios/core/data-inspection.yml
@@ -41,6 +41,7 @@
           switch_mac: "{{ switch.mac }}"
           port: 555
           ae_ip: "{{ ae_ip }}"
+          ae_mac: "00:00:00:00:00:00"
         ok_status: 201
     # For sending INT packets on the #1 of 3 send/receive iteration
     sr1_data_inspection_int:
@@ -77,6 +78,7 @@
           switch_mac: "{{ switch.mac }}"
           port: 555
           ae_ip: "{{ ae_ip }}"
+          ae_mac: "01:02:03:04:05:06"
         ok_status: 201
     # For sending INT packets on the #1 of 3 send/receive iteration
     sr1_data_inspection_int:

--- a/playbooks/scenarios/lab_trial/configure_switches-lab_trial.yml
+++ b/playbooks/scenarios/lab_trial/configure_switches-lab_trial.yml
@@ -30,6 +30,7 @@
           switch_mac: "{{ core.mac }}"
           port: 555
           ae_ip: "{{ ae_ip }}"
+          ae_mac: "{{ ae.mac }}"
         ok_status: 201
       - url: "http://{{ sdn_ip }}:{{ sdn_port }}/dataInspection"
         body:

--- a/trans_sec/bfruntime_lib/core_switch.py
+++ b/trans_sec/bfruntime_lib/core_switch.py
@@ -53,7 +53,10 @@ data_fwd_action_val = 'port'
 
 telem_rpt_tbl = 'TpsCoreEgress.setup_telemetry_rpt_t'
 telem_rpt_tbl_key = 'hdr.udp_int.dst_port'
-telem_rpt_data = 'ae_ip'
+telem_rpt_ae_ip = 'ae_ip'
+telem_rpt_ae_mac = 'ae_mac'
+telem_rpt_action_1 = 'setup_telem_rpt_ipv4'
+telem_rpt_action_2 = 'setup_telem_rpt_ipv6'
 
 trpt_sample_tbl = 'TpsCoreIngress.mirror_sampler'
 trpt_sample_key = '$REGISTER_INDEX'
@@ -119,6 +122,12 @@ class CoreSwitch(BFRuntimeSwitch):
     def __set_table_field_annotations(self):
         df_table = self.get_table(data_fwd_tbl)
         df_table.info.key_field_annotation_add(data_fwd_tbl_key, "mac")
+
+        trpt_table = self.get_table(telem_rpt_tbl)
+        trpt_table.info.data_field_annotation_add(telem_rpt_ae_mac,
+                                                  telem_rpt_action_1, "mac")
+        trpt_table.info.data_field_annotation_add(telem_rpt_ae_mac,
+                                                  telem_rpt_action_2, "mac")
 
     def update_default_port(self, dflt_port):
         logger.info('Setting default port to - [%s]', dflt_port)
@@ -202,7 +211,7 @@ class CoreSwitch(BFRuntimeSwitch):
                     logger.debug("Unable to access table entry info - [%s]", e)
         return ae_ip
 
-    def setup_telemetry_rpt(self, ae_ip, port):
+    def setup_telemetry_rpt(self, ae_ip, ae_mac, port):
         logger.info(
             'Setting up telemetry report on core device [%s] with '
             'AE IP - [%s]', self.device_id, ae_ip)
@@ -215,7 +224,10 @@ class CoreSwitch(BFRuntimeSwitch):
                 telem_rpt_tbl,
                 action_name,
                 [KeyTuple(telem_rpt_tbl_key, value=int(port))],
-                [DataTuple(telem_rpt_data, val=bytearray(ip_addr.packed))])
+                [
+                    DataTuple(telem_rpt_ae_ip, val=bytearray(ip_addr.packed)),
+                    DataTuple(telem_rpt_ae_mac, val=ae_mac),
+                 ])
         except Exception as e:
             if 'ALREADY_EXISTS' in str(e):
                 pass

--- a/trans_sec/bfruntime_lib/core_switch.py
+++ b/trans_sec/bfruntime_lib/core_switch.py
@@ -155,7 +155,7 @@ class CoreSwitch(BFRuntimeSwitch):
         self.delete_table_entry(data_fwd_tbl,
                                 [KeyTuple(data_fwd_tbl_key, value=dst_mac)])
 
-    def __write_clone_entries(self, port, mirror_tbl_key=1):
+    def __write_clone_entries(self, port, mirror_tbl_key=1, max_len=200):
         logger.info('Start mirroring operations on table [%s] to port [%s]',
                     "$mirror.cfg", port)
         mirror_cfg_table = self.get_table("$mirror.cfg")
@@ -167,7 +167,8 @@ class CoreSwitch(BFRuntimeSwitch):
                 DataTuple('$direction', str_val="BOTH"),
                 DataTuple('$ucast_egress_port', port),
                 DataTuple('$ucast_egress_port_valid', bool_val=True),
-                DataTuple('$session_enable', bool_val=True)
+                DataTuple('$session_enable', bool_val=True),
+                DataTuple('$max_pkt_len', max_len),
             ], '$normal')]
         )
 

--- a/trans_sec/controller/core_controller.py
+++ b/trans_sec/controller/core_controller.py
@@ -61,7 +61,8 @@ class CoreController(AbstractController):
     def setup_telem_rpt(self, **kwargs):
         for switch in self.switches:
             if switch.mac == kwargs['switch_mac']:
-                switch.setup_telemetry_rpt(kwargs['ae_ip'], kwargs['port'])
+                switch.setup_telemetry_rpt(kwargs['ae_ip'], kwargs['ae_mac'],
+                                           kwargs['port'])
 
     def set_trpt_sampling_value(self, sample_size):
         for switch in self.switches:

--- a/trans_sec/controller/http_server_flask.py
+++ b/trans_sec/controller/http_server_flask.py
@@ -316,6 +316,7 @@ class TelemetryReport(Resource):
     parser.add_argument('switch_mac', type=str)
     parser.add_argument('port', type=str)
     parser.add_argument('ae_ip', type=str)
+    parser.add_argument('ae_mac', type=str)
 
     def __init__(self, **kwargs):
         self.sdn_controller = kwargs['sdn_controller']


### PR DESCRIPTION
#### What does this PR do?
Fixes #385, Fixes #273, Fixes #388, Fixes #393, Fixes #387

Added TRPT logic only when table is configured
Added bridge metadata to normal packets as mirrored ones have a value of 0x2 and using that value to determine mirroring was poor logic. Now that the egress processing always has a byte added to the header we can parse the headers the same as mirrored packets. Normal packets will have a prepended header byte value of 0x1

#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
ensure CI didn't fail
#### Any background context you want to provide?
Found this bug in the lab_trial environment where the hosts had mac addresses starting with 0x2 as the first byte which was messing up with the parsing logic resulting in the first real byte of the original packet to get dropped.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? yes
- Does the documentation need an update? no
- Does this add new dependencies? no
- Have you added unit or functional tests for this PR? no
